### PR TITLE
style: rename lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "galaw"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "k",
+ "rand",
+ "rand_chacha",
+ "roxmltree",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,17 +441,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "taligalaw"
-version = "0.1.0"
-dependencies = [
- "derive_more",
- "k",
- "rand",
- "rand_chacha",
- "roxmltree",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "taligalaw"
+name = "galaw"
 version = "0.1.0"
 edition = "2024"
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,49 @@
+# galaw — Benchmarking Plan & Competitive Landscape
+
+A native Rust forward-kinematics solver. Goal: match or beat existing solvers
+for a *specialized* robot (via "compile the URDF" code generation), while
+staying pure-cargo — no C++ toolchain, no FFI.
+
+## Rust FK comparison targets
+
+| Library | What it is | Why benchmark against it | Links |
+|---|---|---|---|
+| **k** | General URDF FK/IK on nalgebra; de-facto standard | Accessible baseline — if we can't beat `k`, we can't beat pinocchio | [GitHub](https://github.com/openrr/k) · [crates.io](https://crates.io/crates/k) · [docs.rs](https://docs.rs/k) |
+| **rigidbody-rs** | Featherstone-based URDF kinematics + dynamics | Closest to pinocchio's *algorithm* in pure Rust — the credible "am I competitive?" proxy | [GitHub](https://github.com/khaninger/rigidbody-rs) |
+| **rs-opw-kinematics** | Closed-form FK/IK for 6-axis ortho-parallel/spherical-wrist robots | Not general, but the *specialization ceiling* — the extreme our codegen approaches | [GitHub](https://github.com/bourumir-wyngs/rs-opw-kinematics) · [crates.io](https://crates.io/crates/rs-opw-kinematics) |
+
+## Adjacent / future (IK — not FK, but know they exist)
+
+| Library | What it is | Links |
+|---|---|---|
+| **optik** | Fast optimization-based IK (SE(3), analytic gradients, parallel restarts) | [GitHub](https://github.com/kylc/optik) |
+| **ik-geo** | Geometric/analytical IK | [crates.io](https://crates.io/crates/ik-geo) |
+| **relaxed_ik** | Relaxed IK core | [site](https://pages.graphics.cs.wisc.edu/relaxed_ik_core/) |
+
+## Pinocchio — the gold standard (two separate comparisons)
+
+[Pinocchio](https://github.com/stack-of-tasks/pinocchio) is the C++ reference implementation.
+Benchmark it **two ways**, because they answer different questions:
+
+| Comparison | Question it answers | Notes |
+|---|---|---|
+| **C++ native** (its own `bench/timings.cpp`, or a Python `pin` + `timeit` harness) | Algorithmic ceiling — is our *approach* fundamentally competitive? | Excludes FFI overhead. Honest measure of pinocchio's raw speed. Pinocchio also has a CppADCodeGen path — the specialized-vs-specialized rival. |
+| **Rust via FFI bindings** (would need building with `cxx`) | Realistic incumbent — what a Rust dev *actually* pays today | Includes per-call FFI overhead. Likely where `galaw` wins even without beating raw C++. No mature Rust binding exists — its absence is itself part of our value prop. |
+
+### The "bindings tax" (qualitative, but real for adoption)
+Beyond ns/op, a native crate saves Rust users: no C++ toolchain, no `unsafe`
+FFI boundary, smaller binaries, simpler cross-compilation and deployment.
+
+## Fairness checklist (applies to every comparison)
+
+- [ ] **Same operation** — FK for *all* frames vs. a single frame; recompute vs. cached.
+- [ ] **Exclude model loading** — measure only the warm FK call.
+- [ ] **Release build**, `-O3` / `target-cpu=native` on both sides.
+- [ ] **Single-threaded** unless explicitly measuring throughput.
+- [ ] **Identical robot + identical joint configurations.**
+- [ ] **State single-query vs. batched** explicitly — pinocchio's edge is partly SIMD/batch.
+
+## Foundational (not competitors)
+
+- **urdf-rs** — URDF parser under `k` — [GitHub](https://github.com/openrr/urdf-rs) · [crates.io](https://crates.io/crates/urdf-rs)
+- **nalgebra / parry / rapier** ([dimforge](https://dimforge.com)) — math & physics backbone.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use taligalaw::load_urdf;
+use galaw::load_urdf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let robot_model = load_urdf("assets/simple_robot.urdf")?;
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test commands
     let joint_cmds = [0.0, 0.0];
 
-    // Demo with taligalaw compute_fk
+    // Demo with galaw compute_fk
     match robot_model.compute_fk(&joint_cmds) {
         Ok(links) => {
             for link in robot_model.links.iter() {

--- a/tests/test_fk_correctness.rs
+++ b/tests/test_fk_correctness.rs
@@ -68,7 +68,7 @@ fn assert_tg_fk_matches_k(
     tg_model: &RobotModel,
     k_chain: &k::Chain<f64>,
     joint_cmd: &[f64],
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> TestResult {
     eprintln!("[input] joint_cmd = {:?}", joint_cmd);
 
     let tg_result = tg_model.compute_fk(joint_cmd)?;
@@ -98,14 +98,14 @@ fn setup_kinematic_models() -> (RobotModel, k::Chain<f64>) {
 }
 
 #[test]
-fn test_zero_cmd() -> Result<(), Box<dyn std::error::Error>> {
+fn test_zero_cmd() -> TestResult {
     let (tg_model, k_chain) = setup_kinematic_models();
     let joint_cmd = [0.0, 0.0];
     assert_tg_fk_matches_k(&tg_model, &k_chain, &joint_cmd)
 }
 
 #[test]
-fn test_random_joint_cmds() -> Result<(), Box<dyn std::error::Error>> {
+fn test_random_joint_cmds() -> TestResult {
     let (tg_model, k_chain) = setup_kinematic_models();
     let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
 

--- a/tests/test_fk_correctness.rs
+++ b/tests/test_fk_correctness.rs
@@ -37,10 +37,10 @@ fn assert_position3d_close(a: &Position3D, b: &Position3D) {
     assert_close(a.z, b.z);
 }
 
-fn assert_transform_close(tg_transform: &Transform, k_iso: &k::nalgebra::Isometry3<f64>) {
-    assert_position3d_close(&tg_transform.position, &to_position3d(&k_iso.translation));
+fn assert_transform_close(galaw_transform: &Transform, k_iso: &k::nalgebra::Isometry3<f64>) {
+    assert_position3d_close(&galaw_transform.position, &to_position3d(&k_iso.translation));
     assert_orientation_close(
-        &tg_transform.orientation,
+        &galaw_transform.orientation,
         &to_quaternion(*k_iso.rotation.quaternion()),
     );
 }
@@ -64,26 +64,25 @@ fn to_quaternion(q: k::nalgebra::Quaternion<f64>) -> Quaternion {
     }
 }
 
-fn assert_tg_fk_matches_k(
-    tg_model: &RobotModel,
+fn assert_galaw_fk_matches_k(
+    galaw_model: &RobotModel,
     k_chain: &k::Chain<f64>,
     joint_cmd: &[f64],
 ) -> TestResult {
     eprintln!("[input] joint_cmd = {:?}", joint_cmd);
 
-    let tg_result = tg_model.compute_fk(joint_cmd)?;
+    let galaw_result = galaw_model.compute_fk(joint_cmd)?;
     k_chain.set_joint_positions(joint_cmd)?;
     k_chain.update_transforms();
 
-    for link in tg_model.links.iter() {
-        let tg_link = &tg_result[link];
+    for link in galaw_model.links.iter() {
         let k_link = k_chain
             .find_link(&link.name)
             .unwrap()
             .world_transform()
             .ok_or("invalid result")?;
 
-        assert_transform_close(&tg_result[link], &k_link);
+        assert_transform_close(&galaw_result[link], &k_link);
     }
 
     Ok(())
@@ -92,30 +91,30 @@ fn assert_tg_fk_matches_k(
 /// Because k_chain is stateful, cannot have it easily parallized and need to instantiate it for each test
 fn setup_kinematic_models() -> (RobotModel, k::Chain<f64>) {
     let urdf_path = "assets/simple_robot.urdf";
-    let tg_robot_model = load_urdf(urdf_path).unwrap();
+    let galaw_robot_model = load_urdf(urdf_path).unwrap();
     let k_chain = k::Chain::<f64>::from_urdf_file(urdf_path).unwrap();
-    (tg_robot_model, k_chain)
+    (galaw_robot_model, k_chain)
 }
 
 #[test]
 fn test_zero_cmd() -> TestResult {
-    let (tg_model, k_chain) = setup_kinematic_models();
+    let (galaw_model, k_chain) = setup_kinematic_models();
     let joint_cmd = [0.0, 0.0];
-    assert_tg_fk_matches_k(&tg_model, &k_chain, &joint_cmd)
+    assert_galaw_fk_matches_k(&galaw_model, &k_chain, &joint_cmd)
 }
 
 #[test]
 fn test_random_joint_cmds() -> TestResult {
-    let (tg_model, k_chain) = setup_kinematic_models();
+    let (galaw_model, k_chain) = setup_kinematic_models();
     let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
 
     for _ in 0..128 {
-        let joint_cmds: Vec<f64> = tg_model
+        let joint_cmds: Vec<f64> = galaw_model
             .joints
             .iter()
             .map(|j| rng.random_range(j.limit_lower..j.limit_upper))
             .collect();
-        assert_tg_fk_matches_k(&tg_model, &k_chain, &joint_cmds)?;
+        assert_galaw_fk_matches_k(&galaw_model, &k_chain, &joint_cmds)?;
     }
 
     Ok(())

--- a/tests/test_fk_correctness.rs
+++ b/tests/test_fk_correctness.rs
@@ -5,7 +5,7 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 // Custom
-use taligalaw::{
+use galaw::{
     load_urdf,
     types::{Position3D, Quaternion, RobotModel, Transform},
 };


### PR DESCRIPTION
# Features
- Changed name from "taligalaw" to "galaw". Galaw means movement or motion in Tagalog, better fitting for the library.
- Added doc from Claude to describe benchmarking that is needed to be used to compare galaw's performance. 

# Next Steps
- Change types to use `nalgebra` types
- Change names of types to better generalize (ex. `RobotModel` should be `KinematicModel`).
- Create structs or enums to better encapsulate the types.