### PR TITLE
feat:change compute fk return

### DIFF
--- a/examples/plot_bench.rs
+++ b/examples/plot_bench.rs
@@ -174,7 +174,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Latency: ns/call, CI bounds used directly.
     let latency = build_chart(
-        "FK latency scaling: galaw vs. k (95% CI)",
+        "FK latency scaling (95% CI)",
         "ns per call (lower is better)",
         |s| (s.mean, s.lo, s.hi),
         |x| x.round(),
@@ -186,7 +186,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Throughput: M calls/sec = 1e9 / ns / 1e6. Decreasing in ns, so lo/hi swap.
     let mcps = |ns: f64| 1e9 / ns / 1e6;
     let throughput = build_chart(
-        "FK throughput: galaw vs. k (95% CI)",
+        "FK throughput (95% CI)",
         "M calls/sec (higher is better)",
         move |s| (mcps(s.mean), mcps(s.hi), mcps(s.lo)),
         |x| (x * 100.0).round() / 100.0,

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-
-use crate::types::{Link, Position3D, Quaternion, RobotModel, Transform};
+use crate::types::{Position3D, Quaternion, RobotModel, Transform};
 
 impl RobotModel {
     pub fn compute_fk(
         &self,
         angles: &[f64],
-    ) -> Result<HashMap<Link, Transform>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<Transform>, Box<dyn std::error::Error>> {
         /* Computes forward kinematics of a model */
         if angles.len() != self.joints.len() {
             return Err(format!(
@@ -17,7 +15,7 @@ impl RobotModel {
             .into());
         }
 
-        let mut links: HashMap<Link, Transform> = HashMap::new();
+        let mut links: Vec<Transform> = Vec::new();
         let base_link_transform: Transform = Transform {
             position: Position3D {
                 x: 0.0,
@@ -26,7 +24,7 @@ impl RobotModel {
             },
             orientation: Quaternion::identity(),
         };
-        links.insert(self.links[0].clone(), base_link_transform);
+        links.push(base_link_transform);
 
         for (i, joint) in self.joints.iter().enumerate() {
             // Extracting info about the joint command
@@ -48,7 +46,8 @@ impl RobotModel {
 
             let quat_local: Quaternion = joint.transform.orientation.multiply(&quat_joint);
 
-            let link_prev_quat = links[&self.links[i]].orientation;
+            // let link_prev_quat = links[&self.links[i]].orientation;
+            let link_prev_quat = links[i].orientation;
             let link_n_quat = link_prev_quat.multiply(&quat_local);
 
             let quat_joint_translation = Quaternion {
@@ -65,15 +64,9 @@ impl RobotModel {
                 y: rot_transform.y,
                 z: rot_transform.z,
             };
-            let link_n_position = links[&self.links[i]].position + rot_position;
+            let link_n_position = links[i].position + rot_position;
 
-            links.insert(
-                self.links[i + 1].clone(),
-                Transform {
-                    position: link_n_position,
-                    orientation: link_n_quat,
-                },
-            );
+            links.push(Transform { position: link_n_position, orientation: link_n_quat });
         }
 
         Ok(links)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Demo with galaw compute_fk
     match robot_model.compute_fk(&joint_cmds) {
         Ok(links) => {
-            for link in robot_model.links.iter() {
-                println!("{:?}, {:?}", link, links[link])
+            for (i, link) in robot_model.links.iter().enumerate() {
+                println!("{:?}, {:?}", link, links[i])
             }
         }
         Err(e) => eprintln!("Error: {}", e),

--- a/tests/fk_correctness.rs
+++ b/tests/fk_correctness.rs
@@ -76,14 +76,14 @@ fn assert_galaw_fk_matches_k(
     k_chain.set_joint_positions(joint_cmd)?;
     k_chain.update_transforms();
 
-    for link in galaw_model.links.iter() {
+    for (i, link) in galaw_model.links.iter().enumerate() {
         let k_link = k_chain
             .find_link(&link.name)
             .unwrap()
             .world_transform()
             .ok_or("invalid result")?;
 
-        assert_transform_close(&galaw_result[link], &k_link);
+        assert_transform_close(&galaw_result[i], &k_link);
     }
 
     Ok(())


### PR DESCRIPTION
# Features
- Changed `compute_fk` to return `Vec<Transforms>` rather than `HashMap<Link, Transforms>`. This led to about 62.7-67.9% reduction in latency. 
- Changing plot titles to be more general since will test other FK methods. 

# Results
- New output (notice that `galaw` is either below or above `k` where it matters
<img width="900" height="560" alt="image" src="https://github.com/user-attachments/assets/fc655c9c-0123-4f68-b550-9fb38ec320c6" />
<img width="900" height="560" alt="image" src="https://github.com/user-attachments/assets/54ab1f8c-08fb-4ae8-b06f-c67be7ba54db" />
