### PR TITLE
fix: enforcing link and joint indexing

### DIFF
--- a/assets/simple_robot_flipped.urdf
+++ b/assets/simple_robot_flipped.urdf
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<!--
+  Same robot as simple_robot.urdf (base_link -> upper_arm -> forearm,
+  via shoulder_joint and elbow_joint), but with links and joints
+  declared in reverse order. Used to test that load_urdf's parent/child
+  index resolution is independent of file order, not just lucky.
+-->
+<robot name="simple_arm">
+
+  <material name="black">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+
+  <material name="blue">
+    <color rgba="0.0 0.0 0.8 1.0"/>
+  </material>
+
+  <material name="orange">
+    <color rgba="1.0 0.5 0.0 1.0"/>
+  </material>
+
+  <!-- Links, reversed: forearm, upper_arm, base_link -->
+  <link name="forearm">
+    <visual>
+      <origin xyz="0 0 0.4" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.04" length="0.8"/>
+      </geometry>
+      <material name="blue"/>
+    </visual>
+  </link>
+
+  <link name="upper_arm">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.05" length="1.0"/>
+      </geometry>
+      <material name="orange"/>
+    </visual>
+  </link>
+
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <cylinder radius="0.2" length="0.1"/>
+      </geometry>
+      <material name="black"/>
+    </visual>
+  </link>
+
+  <!-- Joints, reversed: elbow_joint before shoulder_joint -->
+  <joint name="elbow_joint" type="revolute">
+    <parent link="upper_arm"/>
+    <child link="forearm"/>
+    <origin xyz="0 0 0.9" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57" effort="100.0" velocity="1.0"/>
+  </joint>
+
+  <joint name="shoulder_joint" type="revolute">
+    <parent link="base_link"/>
+    <child link="upper_arm"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.57" upper="1.57" effort="100.0" velocity="1.0"/>
+  </joint>
+
+</robot>

--- a/docs/refactor_load_urdf.md
+++ b/docs/refactor_load_urdf.md
@@ -1,0 +1,66 @@
+# Support real-world joint types + fix a latent ordering bug in the URDF parser
+
+## Context
+
+`src/parser.rs`'s `load_urdf` currently assumes every joint is `revolute`: it hard-requires `<axis>` and `<limit>` on every joint and never reads the `type` attribute at all. Real robot URDFs (which the user is about to load) routinely use `fixed` joints (sensor/frame mounts) and `continuous` joints (wheels), and often `prismatic` (grippers, slides) — all of which will fail to parse today. Separately, while investigating how to make command-vector indexing scale to real (possibly branching) robots, I found that `k::Chain` (the crate's own dependency, already used in `tests/fk_correctness.rs` as an independent ground truth) orders its movable joints via **DFS pre-order** (confirmed by reading `k`'s `iterator.rs`/`chain.rs`), while galaw's parser resolves joint order via **BFS**. For today's non-branching chain fixtures the two orders coincide by accident; for any branching real robot they will diverge, silently misassigning commands to the wrong joint. This plan fixes both problems together, since the joint-type work already requires touching the same code path (`cmd_idx` assignment).
+
+User confirmed scope: add support for **revolute, continuous, prismatic, and fixed** joint types (the four that appear in effectively all real robot URDFs).
+
+## Design
+
+### 1. `src/types.rs` — replace parallel `Option`s with an enum
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum JointKinematics {
+    Rotational { axis: Unit<Vector3<f64>>, limits: Option<(f64, f64)> }, // revolute (Some) or continuous (None)
+    Prismatic  { axis: Unit<Vector3<f64>>, limits: Option<(f64, f64)> },
+    Fixed,
+}
+```
+
+- `Joint` drops `axis`/`limit_lower`/`limit_upper` in favor of a single `kinematics: JointKinematics` field — this rules out illegal states (e.g. `Fixed` with an axis) at compile time instead of via convention. This mirrors `k`'s own `JointType` design (it also collapses revolute/continuous into one `Rotational{axis}` variant distinguished only by an optional limit) — useful precedent since we cross-validate against `k` directly in tests.
+- `cmd_idx: usize` → `cmd_idx: Option<usize>` — `Fixed` joints have 0 DOF and must not consume a slot in `joint_cmds` (matches how `k::Chain::dof()`/`movable_nodes` already exclude `Fixed`).
+- Add `GalawModel::num_actuated_joints(&self) -> usize` (count of `cmd_idx.is_some()`), used to size `joint_cmds` and in `compute_fk`'s length check.
+- `joint_name_to_idx` (built in parser.rs) is populated via `filter_map` over joints with `cmd_idx.is_some()`, so `get_joint_idx("some_fixed_joint")` naturally returns `None` — no change needed to the accessor itself, just what gets inserted.
+
+### 2. `src/parser.rs` — split `load_urdf`, fix ordering, support all 4 types
+
+Split the current 170-line function into:
+- **`parse_link(node) -> Result<Link, _>`**
+- **`parse_joint(node) -> Result<Joint, _>`** — reads the `type` attribute and maps it: `revolute`/`continuous` → `Rotational` (limits `Some` for revolute, `None` for continuous — regardless of whether a `<limit>` tag with only `effort`/`velocity` is present), `prismatic` → `Prismatic` (limits required), `fixed` → `Fixed` (no axis/limit read at all). Any other value (`floating`, `planar`, `spherical` — the remaining URDF spec types) is a clear error naming all three as unsupported. Also makes `<origin>` default to identity and `<axis>` default to `(1,0,0)` when omitted, per URDF spec — both are commonly omitted in real files, and requiring them today would fail on well-formed real URDFs.
+- **`resolve_joint_order(links, joints) -> Result<Vec<Joint>, _>`** — root-finding (logic unchanged) + build an adjacency map `HashMap<usize, Vec<usize>>` from `parent_link_idx` → joint indices **in file-declaration order** (built once, O(E); confirmed this matches how `k` itself builds its tree — it iterates `robot.joints` in file order per parent) + a **recursive DFS pre-order** walk (not the current BFS) assigning `cmd_idx = Some(counter)` to non-`Fixed` joints as they're visited, `None` to `Fixed`. Recursion depth is bounded by robot depth (never realistically more than a few dozen), so no stack-depth concern. This replaces the current O(V·E) re-filter-per-pop traversal with O(V+E) and — critically — makes galaw's joint order match `k`'s, so `joint_cmds` built by iterating `model.joints` positionally (as `main.rs`/tests/benches already do) lines up correctly for branching robots, not just chains.
+- `load_urdf` becomes a short orchestrator: parse XML → collect links/joints via the two parse functions → `resolve_joint_order` → build `link_name_to_idx`/`joint_name_to_idx` → construct `GalawModel`.
+
+**Explicitly not doing** (flagging so it's a deliberate choice, not an oversight):
+- No custom error enum — repo has zero precedent (everything is ad-hoc `Box<dyn std::error::Error>`); introducing one now is scope creep beyond what was asked.
+- No submodule split (`parser/xml.rs` etc.) — the file stays single, ~250-300 lines with clearly separated private functions; that's not large enough yet to warrant module boundaries.
+- `<mimic>` is not read/honored. Confirmed `k` itself still gives a mimicked joint a real `Rotational`/`Prismatic` type (it still consumes a DOF slot) — so an unhandled `<mimic>` joint parses and runs fine under this design, it's just controlled independently rather than slaved to its driving joint. `<safety_controller>`/`<calibration>` are metadata-only (confirmed `k` never reads them either) — safe to silently ignore.
+- No cycle detection in `resolve_joint_order`. A malformed URDF where a link is the `child` of two different joints (not a valid tree) could in principle cause unbounded recursion — this is a pre-existing gap (the old BFS had the same non-termination risk), not something introduced by this change, and out of scope for "support real, well-formed robot URDFs."
+
+### 3. `src/kinematics.rs` — branch on joint kinematics
+
+`compute_fk`'s length check uses `self.num_actuated_joints()` instead of `self.joints.len()`. The per-joint loop matches on `joint.kinematics`:
+- `Fixed` → `joint_local = joint.transform` (no command consumed)
+- `Rotational { axis, .. }` → existing rotation-via-axis-angle logic, reading `joint_cmds[joint.cmd_idx.unwrap()]`
+- `Prismatic { axis, .. }` → translation along `axis` scaled by the command value, using `Isometry3::from_parts(Translation3::from(axis.into_inner() * cmd), UnitQuaternion::identity())`, instead of rotation
+
+### 4. Update callers: `src/main.rs`, `tests/fk_correctness.rs`, `benches/fk_speed.rs`
+
+All three currently do `vec![0.0; galaw_model.joints.len()]` and/or iterate `galaw_model.joints` using `j.limit_lower..j.limit_upper` to build random commands. Change to:
+- Size vectors with `galaw_model.num_actuated_joints()`.
+- Filter to `j.cmd_idx.is_some()` (equivalently `joint.kinematics != Fixed`) when building per-joint random values, matching on `joint.kinematics` to get a `(lower, upper)` range — for `Rotational` with `limits: None` (continuous), fall back to a fixed test range like `-PI..PI` since there's no file-declared bound to sample.
+
+### 5. New fixtures + tests (kept as two separate, isolated fixtures so a failure points at one concern)
+
+- **`assets/mixed_joint_types.urdf`** — a single non-branching chain (like today's fixtures) but including one `fixed` link (e.g. a sensor mount), one `continuous` joint, and one `prismatic` joint alongside revolute joints. Isolates joint-type parsing/kinematics-math correctness.
+- **`assets/branching_robot.urdf`** — a root link splitting into two child chains, plain revolute joints only. Isolates the BFS→DFS ordering fix with no confounding joint-type variables.
+- Add both to the existing `fk_correctness_tests!` macro in `tests/fk_correctness.rs` (one line each) — this gets full end-to-end validation against `k::Chain` for free, for both new concerns.
+- New `parser.rs` unit tests: fixed joint parses with no axis/limit; continuous joint has axis but `limits: None`; unsupported joint type (`floating`) errors clearly and names the three unsupported types; `cmd_idx` is `None` for fixed joints and contiguous-from-0 in DFS order for actuated joints; omitted `<origin>`/`<axis>` default correctly.
+
+## Verification
+
+- `cargo test` — the two new fixture-driven tests exercise the full pipeline against `k::Chain` as ground truth (per-link transform comparison), which is the strongest signal that both the joint-type math and the DFS ordering fix are correct.
+- `cargo test --lib` (parser unit tests) for the narrower parsing-only cases.
+- `cargo bench` (optional, user's call) to confirm the adjacency-map rewrite doesn't regress `fk_speed` — should improve or hold steady given O(V+E) vs O(V·E).
+- Per your standing preference, I'll make the edits and explain them; you run `cargo build`/`cargo test`/`cargo bench` yourself.

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -17,15 +17,14 @@ impl GalawModel {
             .into());
         }
 
-        let mut links: Vec<Isometry3<f64>> = Vec::with_capacity(self.joints.len() + 1);
-        links.push(Isometry3::identity());
+        let mut links: Vec<Isometry3<f64>> = vec![Isometry3::identity(); self.links.len()];
 
-        for (i, joint) in self.joints.iter().enumerate() {
+        for joint in &self.joints {
             // Extracting info about the joint command
-            let joint_rotation = UnitQuaternion::from_axis_angle(&joint.axis, joint_cmds[i]);
+            let joint_rotation = UnitQuaternion::from_axis_angle(&joint.axis, joint_cmds[joint.cmd_idx]);
             let joint_local =
                 joint.transform * Isometry3::from_parts(Translation3::identity(), joint_rotation);
-            links.push(links[i] * joint_local);
+            links[joint.child_link_idx] = links[joint.parent_link_idx] * joint_local;
         }
 
         Ok(links)

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -21,7 +21,8 @@ impl GalawModel {
 
         for joint in &self.joints {
             // Extracting info about the joint command
-            let joint_rotation = UnitQuaternion::from_axis_angle(&joint.axis, joint_cmds[joint.cmd_idx]);
+            let joint_rotation =
+                UnitQuaternion::from_axis_angle(&joint.axis, joint_cmds[joint.cmd_idx]);
             let joint_local =
                 joint.transform * Isometry3::from_parts(Translation3::identity(), joint_rotation);
             links[joint.child_link_idx] = links[joint.parent_link_idx] * joint_local;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for joint in galaw_model.joints.iter() {
         let look_up = galaw_model.get_joint_idx(&joint.name);
-        println!("Joint: {:?} -> cmd_idx {} (lookup: {:?})", joint.name, joint.cmd_idx, look_up);
+        println!(
+            "Joint: {:?} -> cmd_idx {} (lookup: {:?})",
+            joint.name, joint.cmd_idx, look_up
+        );
     }
 
     // Building joint_cmd
     let mut joint_cmds = vec![0.0; galaw_model.joints.iter().len()];
-    let shoulder_joint_idx = galaw_model.get_joint_idx("shoulder_joint").ok_or("no shoulder_joint")?;
-    let elbow_joint_idx = galaw_model.get_joint_idx("elbow_joint").ok_or("no elbow_joint")?;
+    let shoulder_joint_idx = galaw_model
+        .get_joint_idx("shoulder_joint")
+        .ok_or("no shoulder_joint")?;
+    let elbow_joint_idx = galaw_model
+        .get_joint_idx("elbow_joint")
+        .ok_or("no elbow_joint")?;
     joint_cmds[shoulder_joint_idx] = 0.5;
     joint_cmds[elbow_joint_idx] = -0.3;
 
@@ -30,6 +37,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             for (i, link) in galaw_model.links.iter().enumerate() {
                 println!("{:?}, {:?}", link, links[i])
             }
+            // Look up a specific link's pose by name, not by assumed position
+            let forearm_idx = galaw_model
+                .get_link_idx("forearm")
+                .ok_or("no forearm link")?;
+            println!("forearm pose (via get_link_idx): {:?}", links[forearm_idx]);
         }
         Err(e) => eprintln!("Error: {}", e),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     for joint in galaw_model.joints.iter() {
-        println!("Joint: {:?}", joint.name);
+        let look_up = galaw_model.get_joint_idx(&joint.name);
+        println!("Joint: {:?} -> cmd_idx {} (lookup: {:?})", joint.name, joint.cmd_idx, look_up);
     }
 
-    // Test commands
-    let joint_cmds = [0.0, 0.0];
+    // Building joint_cmd
+    let mut joint_cmds = vec![0.0; galaw_model.joints.iter().len()];
+    let shoulder_joint_idx = galaw_model.get_joint_idx("shoulder_joint").ok_or("no shoulder_joint")?;
+    let elbow_joint_idx = galaw_model.get_joint_idx("elbow_joint").ok_or("no elbow_joint")?;
+    joint_cmds[shoulder_joint_idx] = 0.5;
+    joint_cmds[elbow_joint_idx] = -0.3;
 
     // Demo with galaw compute_fk
     match galaw_model.compute_fk(&joint_cmds) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 use galaw::load_urdf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let robot_model = load_urdf("assets/simple_robot.urdf")?;
+    let galaw_model = load_urdf("assets/simple_robot.urdf")?;
 
     // Information about the robot
-    println!("robot name: {:?}", robot_model.name);
-    println!("number of links: {:?}", robot_model.links.len());
-    println!("number of joints: {:?}", robot_model.joints.len());
+    println!("robot name: {:?}", galaw_model.name);
+    println!("number of links: {:?}", galaw_model.links.len());
+    println!("number of joints: {:?}", galaw_model.joints.len());
 
-    for link in robot_model.links.iter() {
+    for link in galaw_model.links.iter() {
         println!("Link: {:?}", link.name);
     }
 
-    for joint in robot_model.joints.iter() {
+    for joint in galaw_model.joints.iter() {
         println!("Joint: {:?}", joint.name);
     }
 
@@ -20,9 +20,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let joint_cmds = [0.0, 0.0];
 
     // Demo with galaw compute_fk
-    match robot_model.compute_fk(&joint_cmds) {
+    match galaw_model.compute_fk(&joint_cmds) {
         Ok(links) => {
-            for (i, link) in robot_model.links.iter().enumerate() {
+            for (i, link) in galaw_model.links.iter().enumerate() {
                 println!("{:?}, {:?}", link, links[i])
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 
 // Third-party
@@ -92,19 +93,62 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
             let joint: Joint = Joint {
                 name,
                 parent,
+                parent_link_idx: 0, // Dummy as it will be handled in next lines
                 child,
+                child_link_idx: 1,  // Dummy as it will be handled in next lines
                 transform,
                 axis,
                 limit_lower,
                 limit_upper,
+                cmd_idx: joints.len(),
             };
             joints.push(joint);
         }
     }
 
+    // Enforcing order to ensure indexing is accurate
+    let link_index: HashMap<&str, usize> = 
+        links.iter().enumerate().map(|(i, l)| (l.name.as_str(), i)).collect();
+
+    // Find the root 
+    let child_names: HashSet<&str> = joints.iter().map(|j| j.child.as_str()).collect();
+    let root_candidates: Vec<usize> = links.iter().enumerate()
+        .filter(|(_, l)| !child_names.contains(l.name.as_str()))
+        .map(|(i, _)| i)
+        .collect();
+    let root_index = match root_candidates.as_slice() {
+        [single] => *single,
+        [] => return Err("no root link found - every link has a parent (cycle in URDF?)".into()),
+        _ => {
+            let names: Vec<&str> = root_candidates.iter().map(|&i| links[i].name.as_str()).collect();
+            return Err(format!("multiple root-like links with no parent: {:?} - URDF may be disconnected", names).into());
+        }
+    };
+
+    let mut ordered_joints: Vec<Joint> = Vec::with_capacity(joints.len());
+    let mut queue: VecDeque<usize> = VecDeque::from([root_index]);
+    while let Some(parent_idx) = queue.pop_front() {
+        for j in joints.iter().filter(|j| link_index[j.parent.as_str()] == parent_idx) {
+            let child_idx = link_index[j.child.as_str()];
+            let mut resolved = j.clone();
+            resolved.parent_link_idx = parent_idx;
+            resolved.child_link_idx = child_idx;
+            ordered_joints.push(resolved);
+            queue.push_back(child_idx);
+        }
+    }
+
+    if ordered_joints.len() != joints.len() {
+        return Err("some joints are unreachable from root link (disconnected or cyclic URDF)".into());
+    }
+
+    let joint_name_to_idx: HashMap<String, usize> =
+        ordered_joints.iter().map(|j| (j.name.clone(), j.cmd_idx)).collect();
+
     Ok(GalawModel {
         name: robot_name,
         links: links,
-        joints: joints,
+        joints: ordered_joints,
+        joint_name_to_idx: joint_name_to_idx,
     })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,10 @@ use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
 use crate::types::{Joint, Link, GalawModel};
 use crate::utils::parse_vec3_str;
 
+/// Parses a URDF file into a `GalawModel`.
+/// 
+/// After XML parsing, it resolves the joint order via Breadth-First Search (BFS) 
+/// from the root so `compute_fk` can trust indices instead of file order.
 pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Error>> {
     let content: String = fs::read_to_string(urdf_path)?;
     let doc = roxmltree::Document::parse(&content)?;
@@ -125,6 +129,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
         }
     };
 
+    // Walk the tree from root, resolving parent/child link indices
     let mut ordered_joints: Vec<Joint> = Vec::with_capacity(joints.len());
     let mut queue: VecDeque<usize> = VecDeque::from([root_index]);
     while let Some(parent_idx) = queue.pop_front() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::{clone, fs};
+use std::{fs};
 
 // Third-party
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,3 +157,34 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
         joint_name_to_idx: joint_name_to_idx,
     })
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn joint_resolution_is_independent_of_file_order() {
+        let original = load_urdf("assets/simple_robot.urdf").unwrap();
+        let flipped = load_urdf("assets/simple_robot_flipped.urdf").unwrap();
+
+        // Resolve a joint's parent/child *link names* (not raw indices —
+        // those are expected to differ between the two files, since the
+        // links are declared in a different order in each).
+        fn parent_child_names(model: &GalawModel, joint_name: &str) -> (String, String) {
+            let joint = model.joints.iter().find(|j| j.name == joint_name).unwrap();
+            (
+                model.links[joint.parent_link_idx].name.clone(),
+                model.links[joint.child_link_idx].name.clone(),
+            )
+        }
+
+        for joint_name in ["shoulder_joint", "elbow_joint"] {
+            assert_eq!(
+                parent_child_names(&original, joint_name),
+                parent_child_names(&flipped, joint_name),
+                "joint {joint_name} resolved to a different parent/child link depending on file order"
+            );
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,16 +1,16 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs;
+use std::{clone, fs};
 
 // Third-party
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
 
 // Custom
-use crate::types::{Joint, Link, GalawModel};
+use crate::types::{GalawModel, Joint, Link};
 use crate::utils::parse_vec3_str;
 
 /// Parses a URDF file into a `GalawModel`.
-/// 
-/// After XML parsing, it resolves the joint order via Breadth-First Search (BFS) 
+///
+/// After XML parsing, it resolves the joint order via Breadth-First Search (BFS)
 /// from the root so `compute_fk` can trust indices instead of file order.
 pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Error>> {
     let content: String = fs::read_to_string(urdf_path)?;
@@ -99,7 +99,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
                 parent,
                 parent_link_idx: 0, // Dummy as it will be handled in next lines
                 child,
-                child_link_idx: 1,  // Dummy as it will be handled in next lines
+                child_link_idx: 1, // Dummy as it will be handled in next lines
                 transform,
                 axis,
                 limit_lower,
@@ -111,12 +111,17 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
     }
 
     // Enforcing order to ensure indexing is accurate
-    let link_index: HashMap<&str, usize> = 
-        links.iter().enumerate().map(|(i, l)| (l.name.as_str(), i)).collect();
+    let link_index: HashMap<&str, usize> = links
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.name.as_str(), i))
+        .collect();
 
-    // Find the root 
+    // Find the root
     let child_names: HashSet<&str> = joints.iter().map(|j| j.child.as_str()).collect();
-    let root_candidates: Vec<usize> = links.iter().enumerate()
+    let root_candidates: Vec<usize> = links
+        .iter()
+        .enumerate()
         .filter(|(_, l)| !child_names.contains(l.name.as_str()))
         .map(|(i, _)| i)
         .collect();
@@ -124,8 +129,15 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
         [single] => *single,
         [] => return Err("no root link found - every link has a parent (cycle in URDF?)".into()),
         _ => {
-            let names: Vec<&str> = root_candidates.iter().map(|&i| links[i].name.as_str()).collect();
-            return Err(format!("multiple root-like links with no parent: {:?} - URDF may be disconnected", names).into());
+            let names: Vec<&str> = root_candidates
+                .iter()
+                .map(|&i| links[i].name.as_str())
+                .collect();
+            return Err(format!(
+                "multiple root-like links with no parent: {:?} - URDF may be disconnected",
+                names
+            )
+            .into());
         }
     };
 
@@ -133,7 +145,10 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
     let mut ordered_joints: Vec<Joint> = Vec::with_capacity(joints.len());
     let mut queue: VecDeque<usize> = VecDeque::from([root_index]);
     while let Some(parent_idx) = queue.pop_front() {
-        for j in joints.iter().filter(|j| link_index[j.parent.as_str()] == parent_idx) {
+        for j in joints
+            .iter()
+            .filter(|j| link_index[j.parent.as_str()] == parent_idx)
+        {
             let child_idx = link_index[j.child.as_str()];
             let mut resolved = j.clone();
             resolved.parent_link_idx = parent_idx;
@@ -144,25 +159,61 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
     }
 
     if ordered_joints.len() != joints.len() {
-        return Err("some joints are unreachable from root link (disconnected or cyclic URDF)".into());
+        return Err(
+            "some joints are unreachable from root link (disconnected or cyclic URDF)".into(),
+        );
     }
 
-    let joint_name_to_idx: HashMap<String, usize> =
-        ordered_joints.iter().map(|j| (j.name.clone(), j.cmd_idx)).collect();
+    let link_name_to_idx: HashMap<String, usize> = links
+        .iter()
+        .enumerate()
+        .map(|(i, l)| (l.name.clone(), i))
+        .collect();
+
+    let joint_name_to_idx: HashMap<String, usize> = ordered_joints
+        .iter()
+        .map(|j| (j.name.clone(), j.cmd_idx))
+        .collect();
 
     Ok(GalawModel {
         name: robot_name,
         links: links,
+        link_name_to_idx: link_name_to_idx,
         joints: ordered_joints,
         joint_name_to_idx: joint_name_to_idx,
     })
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// get_link_idx must resolve to the right link, for every link, in
+    /// both file orderings — guards against index/link mappings drifting
+    /// out of sync (not needed to catch today's bug, but the same bug
+    /// class as the joint resolution issue below).
+    #[test]
+    fn link_lookup_is_self_consistent() {
+        for path in [
+            "assets/simple_robot.urdf",
+            "assets/simple_robot_flipped.urdf",
+        ] {
+            let model = load_urdf(path).unwrap();
+            for link in &model.links {
+                let idx = model.get_link_idx(&link.name).unwrap_or_else(|| {
+                    panic!("get_link_idx(\"{}\") returned None in {path}", link.name)
+                });
+                assert_eq!(
+                    model.links[idx].name, link.name,
+                    "get_link_idx(\"{}\") in {path} pointed at the wrong link",
+                    link.name
+                );
+            }
+        }
+    }
+
+    /// Same robot, links/joints in a different file order — resolved
+    /// parent/child link names must match regardless.
     #[test]
     fn joint_resolution_is_independent_of_file_order() {
         let original = load_urdf("assets/simple_robot.urdf").unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nalgebra::{Isometry3, Unit, Vector3};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -5,15 +7,18 @@ pub struct Link {
     pub name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Joint {
     pub name: String,
     pub parent: String,
+    pub parent_link_idx: usize,
     pub child: String,
+    pub child_link_idx: usize,
     pub transform: Isometry3<f64>,
     pub axis: Unit<Vector3<f64>>,
     pub limit_lower: f64,
     pub limit_upper: f64,
+    pub cmd_idx: usize,
 }
 
 #[derive(Debug)]
@@ -21,4 +26,11 @@ pub struct GalawModel {
     pub name: String,
     pub links: Vec<Link>,
     pub joints: Vec<Joint>,
+    pub joint_name_to_idx: HashMap<String, usize>,
+}
+
+impl GalawModel {
+    pub fn get_joint_idx(&self, name: &str) -> Option<usize> {
+        self.joint_name_to_idx.get(name).copied()
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,10 +26,15 @@ pub struct GalawModel {
     pub name: String,
     pub links: Vec<Link>,
     pub joints: Vec<Joint>,
+    pub link_name_to_idx: HashMap<String, usize>,
     pub joint_name_to_idx: HashMap<String, usize>,
 }
 
 impl GalawModel {
+    pub fn get_link_idx(&self, name: &str) -> Option<usize> {
+        self.link_name_to_idx.get(name).copied()
+    }
+
     pub fn get_joint_idx(&self, name: &str) -> Option<usize> {
         self.joint_name_to_idx.get(name).copied()
     }

--- a/tests/fk_correctness.rs
+++ b/tests/fk_correctness.rs
@@ -1,6 +1,5 @@
 /// Tests the correctness of the implmeented forward kinematics function
 /// with Rust's k library
-
 // Third-party
 use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 use rand::{RngExt, SeedableRng};


### PR DESCRIPTION
# Features
- Fixing implicit assumption of link and joint ordering in URDF, which is not reasonable. 
- Created regression test to prevent this issue. 

# Next Steps
- Refactor `parser.rs` to support real robot URDFs with more varied joint types. 