### PR TITLE
refactor: error logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "v_frame",
  "y4m",
 ]
@@ -717,7 +717,7 @@ dependencies = [
  "smallvec",
  "sourcemap",
  "static_assertions",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "v8",
@@ -769,7 +769,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syn 2.0.118",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ dependencies = [
  "deno_error",
  "percent-encoding",
  "sys_traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -1145,6 +1145,7 @@ dependencies = [
  "roxmltree",
  "serde_json",
  "sysinfo",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1230,7 +1231,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2379,7 +2380,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2702,7 +2703,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "v8",
 ]
 
@@ -2939,6 +2940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,11 +3013,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -3021,13 +3033,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3449,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51cf5f08b357e64cd7642ab4bbeb11aecab9e15520692129624fb9908b8df2c"
 dependencies = [
  "deno_error",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 derive_more = {version="2.1.1", features=["add"]}
 nalgebra = "0.30.1"
 roxmltree = "0.20.0"
+thiserror = "2.0.19"
 
 [dev-dependencies]
 charming = { version = "0.6.0", features = ["ssr-raster"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,45 +19,45 @@ pub enum UrdfParseError {
         source: roxmltree::Error,
     },
     #[error("robot tag missing name attribute")]
-    MissingXmlAttributeRobotName,
+    MissingAttributeRobotName,
     #[error("link tag missing name attribute")]
-    MissingXmlAttributeLinkName,
+    MissingAttributeLinkName,
 
     // Errors for <joint/>
     #[error("joint tag missing name attribute")]
-    MissingXmlAttributeJointName,
+    MissingAttributeJointName,
     #[error("joint {0} missing type attribute")]
-    MissingXmlAttributeJointType(String),
+    MissingAttributeJointType(String),
 
     // <parent/>
     #[error("missing parent tag for joint {0}")]
-    MissingXmlTagJointParent(String),
+    MissingTagJointParent(String),
     #[error("missing parent link for joint {0}")]
-    MissingXmlAttributeJointParentLink(String),
+    MissingAttributeJointParentLink(String),
 
     // <child/>
     #[error("missing child tag for joint {0}")]
-    MissingXmlTagChildLink(String),
+    MissingTagChildLink(String),
     #[error("missing child link for joint {0}")]
-    MissingXmlAttributeJointChildLink(String),
+    MissingAttributeJointChildLink(String),
 
     // <origin/>
     #[error("joint {0} missing origin")]
-    MissingXmlTagJointOrigin(String),
+    MissingTagJointOrigin(String),
     #[error("missing xyz data for joint {0}")]
-    MissingXmlAttributeJointOriginXyz(String),
+    MissingAttributeJointOriginXyz(String),
     #[error("missing rpy data for joint {0}")]
-    MissingXmlAttributeJointOriginRpy(String),
+    MissingAttributeJointOriginRpy(String),
 
     // <axis/>
     #[error("missing axis xyz data for joint {0}")]
-    MissingXmlAttributeJointAxisXyz(String),
+    MissingAttributeJointAxisXyz(String),
 
     // <limit/>
     #[error("missing joint limit tag for joint {0}")]
-    MissingXmlTagJointLimit(String),
+    MissingTagJointLimit(String),
     #[error("missing joint limit lower attribute for joint {0}")]
-    MissingXmlAttributeJointLimitLower(String),
+    MissingAttributeJointLimitLower(String),
     #[error("missing joint limit upper attribute for joint {0}")]
-    MissingXmlAttributeJointLimitUpper(String),
+    MissingAttributeJointLimitUpper(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,63 @@
+#[derive(Debug, thiserror::Error)]
+pub enum GalawError {
+    #[error(transparent)]
+    Parse(#[from] UrdfParseError)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UrdfParseError {
+    #[error("failed to read URDF file {path}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("invalid XML content: {xml_content}")]
+    XmlParse {
+        xml_content: String,
+        #[source]
+        source: roxmltree::Error,
+    },
+    #[error("robot tag missing name attribute")]
+    MissingXmlAttributeRobotName,
+    #[error("link tag missing name attribute")]
+    MissingXmlAttributeLinkName,
+
+    // Errors for <joint/>
+    #[error("joint tag missing name attribute")]
+    MissingXmlAttributeJointName,
+    #[error("joint {0} missing type attribute")]
+    MissingXmlAttributeJointType(String),
+
+    // <parent/>
+    #[error("missing parent tag for joint {0}")]
+    MissingXmlTagJointParent(String),
+    #[error("missing parent link for joint {0}")]
+    MissingXmlAttributeJointParentLink(String),
+
+    // <child/>
+    #[error("missing child tag for joint {0}")]
+    MissingXmlTagChildLink(String),
+    #[error("missing child link for joint {0}")]
+    MissingXmlAttributeJointChildLink(String),
+
+    // <origin/>
+    #[error("joint {0} missing origin")]
+    MissingXmlTagJointOrigin(String),
+    #[error("missing xyz data for joint {0}")]
+    MissingXmlAttributeJointOriginXyz(String),
+    #[error("missing rpy data for joint {0}")]
+    MissingXmlAttributeJointOriginRpy(String),
+
+    // <axis/>
+    #[error("missing axis xyz data for joint {0}")]
+    MissingXmlAttributeJointAxisXyz(String),
+
+    // <limit/>
+    #[error("missing joint limit tag for joint {0}")]
+    MissingXmlTagJointLimit(String),
+    #[error("missing joint limit lower attribute for joint {0}")]
+    MissingXmlAttributeJointLimitLower(String),
+    #[error("missing joint limit upper attribute for joint {0}")]
+    MissingXmlAttributeJointLimitUpper(String),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum UrdfParseError {
         #[source]
         source: roxmltree::Error,
     },
+    #[error("expected 3 values, recieved {0} of length {1}")]
+    InvalidVector3Len(String, usize),
     #[error("robot tag missing name attribute")]
     MissingAttributeRobotName,
     #[error("link tag missing name attribute")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ pub enum UrdfParseError {
 
     // <child/>
     #[error("missing child tag for joint {0}")]
-    MissingTagChildLink(String),
+    MissingTagJointChild(String),
     #[error("missing child link for joint {0}")]
     MissingAttributeJointChildLink(String),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,11 @@ pub enum UrdfParseError {
     MissingAttributeJointName,
     #[error("joint {0} missing type attribute")]
     MissingAttributeJointType(String),
+    #[error("unknown joint type '{found}' for joint {name}")]
+    UnknownJointType {
+        name: String,
+        found: String,
+    },
 
     // <parent/>
     #[error("missing parent tag for joint {0}")]
@@ -60,4 +65,9 @@ pub enum UrdfParseError {
     MissingAttributeJointLimitLower(String),
     #[error("missing joint limit upper attribute for joint {0}")]
     MissingAttributeJointLimitUpper(String),
+    #[error("value is invalid number: {value}")]
+    InvalidNumberFormat {
+        value: String,
+        source: std::num::ParseFloatError,
+    },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ pub enum GalawError {
     Parse(#[from] UrdfParseError),
     #[error(transparent)]
     ModelTopology(#[from] ModelTopologyError),
+    #[error(transparent)]
+    Kinematics(#[from] KinematicsError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -87,4 +89,13 @@ pub enum ModelTopologyError {
     DisconnectedJoints(Vec<String>),
     #[error("link has a cyclic connection: {0}")]
     CyclicLink(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KinematicsError {
+    #[error("expected {num_actuated} joint cmds, recieved {num_input}")]
+    JointCmdLengthMismatch {
+        num_actuated: usize,
+        num_input: usize,
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,8 @@ pub enum ModelTopologyError {
     MissingRootLink,
     #[error("multiple root-like links found (URDF may be disconnected): {0:?}")]
     MultipleRootLinks(Vec<String>),
-    #[error("joint is unreachable from root (disconnected or cyclic)")]
-    DisconnectedOrCyclicJoints,
+    #[error("joint is unreachable from root - URDF may be disconnected: {0:?}")]
+    DisconnectedJoints(Vec<String>),
+    #[error("link has a cyclic connection: {0}")]
+    CyclicLink(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,9 +16,9 @@ pub enum UrdfParseError {
         #[source]
         source: std::io::Error,
     },
-    #[error("failed to parse XML content: '{xml_content}'")]
+    #[error("failed to parse XML in URDF file '{path}': {source}")]
     XmlParse {
-        xml_content: String,
+        path: String,
         #[source]
         source: roxmltree::Error,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,86 +10,87 @@ pub enum GalawError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum UrdfParseError {
-    #[error("failed to read URDF file {path}")]
+    #[error("failed to read URDF file '{path}'")]
     Io {
         path: String,
         #[source]
         source: std::io::Error,
     },
-    #[error("invalid XML content: {xml_content}")]
+    #[error("failed to parse XML content: '{xml_content}'")]
     XmlParse {
         xml_content: String,
         #[source]
         source: roxmltree::Error,
     },
-    #[error("expected 3 values, recieved {0} of length {1}")]
+    #[error("expected 3 values, received {1} in '{0}'")]
     InvalidVector3Len(String, usize),
-    #[error("robot tag missing name attribute")]
+    #[error("missing 'name' attribute on <robot> tag")]
     MissingAttributeRobotName,
-    #[error("link tag missing name attribute")]
+    #[error("missing 'name' attribute on <link> tag")]
     MissingAttributeLinkName,
 
     // Errors for <joint/>
-    #[error("joint tag missing name attribute")]
+    #[error("missing 'name' attribute on <joint> tag")]
     MissingAttributeJointName,
-    #[error("joint {0} missing type attribute")]
+    #[error("missing 'type' attribute for joint '{0}'")]
     MissingAttributeJointType(String),
-    #[error("unknown joint type '{found}' for joint {name}")]
+    #[error("unknown joint type '{found}' for joint '{name}'")]
     UnknownJointType { name: String, found: String },
 
     // <parent/>
-    #[error("missing parent tag for joint {0}")]
+    #[error("missing '<parent>' tag for joint '{0}'")]
     MissingTagJointParent(String),
-    #[error("missing parent link for joint {0}")]
+    #[error("missing 'link' attribute on <parent> tag for joint '{0}'")]
     MissingAttributeJointParentLink(String),
 
     // <child/>
-    #[error("missing child tag for joint {0}")]
+    #[error("missing '<child>' tag for joint '{0}'")]
     MissingTagJointChild(String),
-    #[error("missing child link for joint {0}")]
+    #[error("missing 'link' attribute on <child> tag for joint '{0}'")]
     MissingAttributeJointChildLink(String),
 
     // <origin/>
-    #[error("joint {0} missing origin")]
+    #[error("missing '<origin>' tag for joint '{0}'")]
     MissingTagJointOrigin(String),
-    #[error("missing xyz data for joint {0}")]
+    #[error("missing 'xyz' attribute on <origin> tag for joint '{0}'")]
     MissingAttributeJointOriginXyz(String),
-    #[error("missing rpy data for joint {0}")]
+    #[error("missing 'rpy' attribute on <origin> tag for joint '{0}'")]
     MissingAttributeJointOriginRpy(String),
 
     // <axis/>
-    #[error("missing axis xyz data for joint {0}")]
+    #[error("missing 'xyz' attribute on <axis> tag for joint '{0}'")]
     MissingAttributeJointAxisXyz(String),
 
     // <limit/>
-    #[error("missing joint limit tag for joint {0}")]
+    #[error("missing '<limit>' tag for joint '{0}'")]
     MissingTagJointLimit(String),
-    #[error("missing joint limit lower attribute for joint {0}")]
+    #[error("missing 'lower' attribute on <limit> tag for joint '{0}'")]
     MissingAttributeJointLimitLower(String),
-    #[error("missing joint limit upper attribute for joint {0}")]
+    #[error("missing 'upper' attribute on <limit> tag for joint '{0}'")]
     MissingAttributeJointLimitUpper(String),
-    #[error("value is invalid number: {value}")]
+    #[error("invalid number '{value}'")]
     InvalidNumberFormat {
         value: String,
+        #[source]
         source: std::num::ParseFloatError,
     },
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ModelTopologyError {
-    #[error("no root link found. Every link has a parent (maybe a cycle in URDF).")]
+    #[error("no root link found, every link has a parent (URDF may contain a cycle)")]
     MissingRootLink,
-    #[error("multiple root-like links found (URDF may be disconnected): {0:?}")]
+    #[error("multiple root-like links found, URDF may be disconnected: {0:?}")]
     MultipleRootLinks(Vec<String>),
-    #[error("joint is unreachable from root - URDF may be disconnected: {0:?}")]
+    #[error("joint unreachable from root, URDF may be disconnected: {0:?}")]
     DisconnectedJoints(Vec<String>),
-    #[error("link has a cyclic connection: {0}")]
+    #[error("link '{0}' has a cyclic connection")]
     CyclicLink(String),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum KinematicsError {
-    #[error("expected {num_actuated} joint cmds, recieved {num_input}")]
+    #[error("expected {num_actuated} joint cmds, received {num_input}")]
     JointCmdLengthMismatch {
         num_actuated: usize,
         num_input: usize,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,9 @@
 #[derive(Debug, thiserror::Error)]
 pub enum GalawError {
     #[error(transparent)]
-    Parse(#[from] UrdfParseError)
+    Parse(#[from] UrdfParseError),
+    #[error(transparent)]
+    ModelTopology(#[from] ModelTopologyError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,4 +74,15 @@ pub enum UrdfParseError {
         value: String,
         source: std::num::ParseFloatError,
     },
+}
+
+
+#[derive(Debug, thiserror::Error)]
+pub enum ModelTopologyError {
+    #[error("no root link found. Every link has a parent (maybe a cycle in URDF).")]
+    MissingRootLink,
+    #[error("multiple root-like links found (URDF may be disconnected): {0:?}")]
+    MultipleRootLinks(Vec<String>),
+    #[error("joint is unreachable from root (disconnected or cyclic)")]
+    DisconnectedOrCyclicJoints,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,10 +35,7 @@ pub enum UrdfParseError {
     #[error("joint {0} missing type attribute")]
     MissingAttributeJointType(String),
     #[error("unknown joint type '{found}' for joint {name}")]
-    UnknownJointType {
-        name: String,
-        found: String,
-    },
+    UnknownJointType { name: String, found: String },
 
     // <parent/>
     #[error("missing parent tag for joint {0}")]
@@ -78,7 +75,6 @@ pub enum UrdfParseError {
     },
 }
 
-
 #[derive(Debug, thiserror::Error)]
 pub enum ModelTopologyError {
     #[error("no root link found. Every link has a parent (maybe a cycle in URDF).")]
@@ -97,5 +93,5 @@ pub enum KinematicsError {
     JointCmdLengthMismatch {
         num_actuated: usize,
         num_input: usize,
-    }
+    },
 }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -9,7 +9,11 @@ impl GalawModel {
         joint_cmds: &[f64],
     ) -> Result<Vec<Isometry3<f64>>, Box<dyn std::error::Error>> {
         if joint_cmds.len() != self.num_actuated_joints {
-            return Err(KinematicsError::JointCmdLengthMismatch { num_actuated: self.num_actuated_joints, num_input: joint_cmds.len() }.into());
+            return Err(KinematicsError::JointCmdLengthMismatch {
+                num_actuated: self.num_actuated_joints,
+                num_input: joint_cmds.len(),
+            }
+            .into());
         }
 
         let mut links: Vec<Isometry3<f64>> = vec![Isometry3::identity(); self.links.len()];

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,13 +1,13 @@
 use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 
-use crate::{error::{GalawError, KinematicsError}, types::GalawModel};
+use crate::{
+    error::{GalawError, KinematicsError},
+    types::GalawModel,
+};
 
 impl GalawModel {
     /// Computes forward kinematics of a model
-    pub fn compute_fk(
-        &self,
-        joint_cmds: &[f64],
-    ) -> Result<Vec<Isometry3<f64>>, GalawError> {
+    pub fn compute_fk(&self, joint_cmds: &[f64]) -> Result<Vec<Isometry3<f64>>, GalawError> {
         if joint_cmds.len() != self.num_actuated_joints {
             return Err(KinematicsError::JointCmdLengthMismatch {
                 num_actuated: self.num_actuated_joints,

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,6 +1,6 @@
 use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 
-use crate::types::GalawModel;
+use crate::{error::KinematicsError, types::GalawModel};
 
 impl GalawModel {
     /// Computes forward kinematics of a model
@@ -9,12 +9,7 @@ impl GalawModel {
         joint_cmds: &[f64],
     ) -> Result<Vec<Isometry3<f64>>, Box<dyn std::error::Error>> {
         if joint_cmds.len() != self.num_actuated_joints {
-            return Err(format!(
-                "expected {} joint_cmds, got {}",
-                self.joints.len(),
-                joint_cmds.len()
-            )
-            .into());
+            return Err(KinematicsError::JointCmdLengthMismatch { num_actuated: self.num_actuated_joints, num_input: joint_cmds.len() }.into());
         }
 
         let mut links: Vec<Isometry3<f64>> = vec![Isometry3::identity(); self.links.len()];

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,13 +1,13 @@
 use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 
-use crate::{error::KinematicsError, types::GalawModel};
+use crate::{error::{GalawError, KinematicsError}, types::GalawModel};
 
 impl GalawModel {
     /// Computes forward kinematics of a model
     pub fn compute_fk(
         &self,
         joint_cmds: &[f64],
-    ) -> Result<Vec<Isometry3<f64>>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<Isometry3<f64>>, GalawError> {
         if joint_cmds.len() != self.num_actuated_joints {
             return Err(KinematicsError::JointCmdLengthMismatch {
                 num_actuated: self.num_actuated_joints,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod fixtures;
 pub mod generated;
 pub mod kinematics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use galaw::{load_urdf};
+use galaw::load_urdf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let galaw_model = load_urdf("assets/urdf/custom/simple_arm_2dof.urdf")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use galaw::load_urdf;
+use galaw::{load_urdf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let galaw_model = load_urdf("assets/urdf/custom/simple_arm_2dof.urdf")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,7 +21,7 @@ fn read_axis(
         .children()
         .find(|n| n.tag_name().name() == "axis")
         .and_then(|n| n.attribute("xyz"))
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointAxisXyz(joint_name.to_string()))?;
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointAxisXyz(joint_name.to_string()))?;
     let (axis_x, axis_y, axis_z) = parse_vec3_str(axis_str)?;
 
     Ok(Unit::new_normalize(Vector3::new(axis_x, axis_y, axis_z)))
@@ -37,15 +37,15 @@ fn read_joint_limits(
     let joint_limit = node
         .children()
         .find(|n| n.tag_name().name() == "limit")
-        .ok_or_else(|| UrdfParseError::MissingXmlTagJointLimit(joint_name.to_string()))?;
+        .ok_or_else(|| UrdfParseError::MissingTagJointLimit(joint_name.to_string()))?;
 
     let limit_lower: f64 = joint_limit
         .attribute("lower")
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointLimitLower(joint_name.to_string()))?
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitLower(joint_name.to_string()))?
         .parse::<f64>()?;
     let limit_upper: f64 = joint_limit
         .attribute("upper")
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointLimitUpper(joint_name.to_string()))?
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitUpper(joint_name.to_string()))?
         .parse::<f64>()?;
 
     Ok((limit_lower, limit_upper))
@@ -55,7 +55,7 @@ fn read_joint_limits(
 fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error::Error>> {
     let link_name: String = node
         .attribute("name")
-        .ok_or(UrdfParseError::MissingXmlAttributeLinkName)?
+        .ok_or(UrdfParseError::MissingAttributeLinkName)?
         .to_string();
     Ok(Link { name: link_name })
 }
@@ -64,40 +64,40 @@ fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error:
 fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::error::Error>> {
     let name: String = node
         .attribute("name")
-        .ok_or(UrdfParseError::MissingXmlAttributeJointName)?
+        .ok_or(UrdfParseError::MissingAttributeJointName)?
         .to_string();
     let joint_type: JointType = node
         .attribute("type")
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointType(name.clone()))?
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointType(name.clone()))?
         .parse()?;
     let parent: String = node
         .children()
         .find(|n| n.tag_name().name() == "parent")
         .and_then(|n| n.attribute("link"))
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointParentLink(name.clone()))?
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointParentLink(name.clone()))?
         .to_string();
     let child: String = node
         .children()
         .find(|n| n.tag_name().name() == "child")
         .and_then(|n| n.attribute("link"))
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointChildLink(name.clone()))?
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointChildLink(name.clone()))?
         .to_string();
 
     // Extracting joint XYZ and RPY
     let joint_origin = node
         .children()
         .find(|n| n.tag_name().name() == "origin")
-        .ok_or_else(|| UrdfParseError::MissingXmlTagJointOrigin(name.clone()))?;
+        .ok_or_else(|| UrdfParseError::MissingTagJointOrigin(name.clone()))?;
 
     let xyz_str: &str = joint_origin
         .attribute("xyz")
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointOriginXyz(name.clone()))?;
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointOriginXyz(name.clone()))?;
     let (x, y, z) = parse_vec3_str(xyz_str)?;
     let xyz = Vector3::new(x, y, z);
 
     let rpy_str = joint_origin
         .attribute("rpy")
-        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointOriginRpy(name.clone()))?;
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointOriginRpy(name.clone()))?;
     let (roll, pitch, yaw) = parse_vec3_str(rpy_str)?;
     let rotation = UnitQuaternion::from_euler_angles(roll, pitch, yaw);
 
@@ -283,7 +283,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Erro
     let robot_name: String = doc
         .root_element()
         .attribute("name")
-        .ok_or(UrdfParseError::MissingXmlAttributeRobotName)?
+        .ok_or(UrdfParseError::MissingAttributeRobotName)?
         .to_string();
     let mut links: Vec<Link> = Vec::new();
     let mut joints: Vec<Joint> = Vec::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use std::fs;
 
 // Third-party
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
+use roxmltree::Node;
 
 // Custom
 use crate::error::{UrdfParseError};
@@ -70,20 +71,28 @@ fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::erro
         .attribute("type")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointType(name.clone()))?
         .parse()?;
-    let parent: String = node
+
+    // Extracting parent info
+    let joint_parent: roxmltree::Node<'_, '_> = node
         .children()
         .find(|n| n.tag_name().name() == "parent")
-        .and_then(|n| n.attribute("link"))
+        .ok_or_else(|| UrdfParseError::MissingTagJointParent(name.clone()))?;
+    let parent: String = joint_parent
+        .attribute("link")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointParentLink(name.clone()))?
         .to_string();
-    let child: String = node
+
+    // Extracting child info
+    let joint_child: roxmltree::Node<'_, '_> = node
         .children()
         .find(|n| n.tag_name().name() == "child")
-        .and_then(|n| n.attribute("link"))
+        .ok_or_else(|| UrdfParseError::MissingTagJointChild(name.clone()))?;
+    let child: String = joint_child
+        .attribute("link")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointChildLink(name.clone()))?
         .to_string();
 
-    // Extracting joint XYZ and RPY
+    // Extracting joint XYZ and RPY and constructing transform
     let joint_origin = node
         .children()
         .find(|n| n.tag_name().name() == "origin")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,8 +5,10 @@ use std::fs;
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
 
 // Custom
+use crate::error::{UrdfParseError};
 use crate::types::{GalawModel, Joint, JointType, Link};
 use crate::utils::parse_vec3_str;
+
 
 // ----- HELPER METHODS -----
 /// Parses the axis information from tag
@@ -19,7 +21,7 @@ fn read_axis(
         .children()
         .find(|n| n.tag_name().name() == "axis")
         .and_then(|n| n.attribute("xyz"))
-        .ok_or_else(|| format!("missing axis xyz value for joint {}", joint_name))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointAxisXyz(joint_name.to_string()))?;
     let (axis_x, axis_y, axis_z) = parse_vec3_str(axis_str)?;
 
     Ok(Unit::new_normalize(Vector3::new(axis_x, axis_y, axis_z)))
@@ -35,15 +37,15 @@ fn read_joint_limits(
     let joint_limit = node
         .children()
         .find(|n| n.tag_name().name() == "limit")
-        .ok_or_else(|| format!("missing joint limits for joint {}", joint_name))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlTagJointLimit(joint_name.to_string()))?;
 
     let limit_lower: f64 = joint_limit
         .attribute("lower")
-        .ok_or_else(|| format!("missing joint limit lower for joint {}", joint_name))?
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointLimitLower(joint_name.to_string()))?
         .parse::<f64>()?;
     let limit_upper: f64 = joint_limit
         .attribute("upper")
-        .ok_or_else(|| format!("missing joint limit upper for joint {}", joint_name))?
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointLimitUpper(joint_name.to_string()))?
         .parse::<f64>()?;
 
     Ok((limit_lower, limit_upper))
@@ -53,7 +55,7 @@ fn read_joint_limits(
 fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error::Error>> {
     let link_name: String = node
         .attribute("name")
-        .ok_or("link missing name attribute")?
+        .ok_or(UrdfParseError::MissingXmlAttributeLinkName)?
         .to_string();
     Ok(Link { name: link_name })
 }
@@ -62,41 +64,40 @@ fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error:
 fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::error::Error>> {
     let name: String = node
         .attribute("name")
-        .ok_or("joint missing name attribute")?
+        .ok_or(UrdfParseError::MissingXmlAttributeJointName)?
         .to_string();
     let joint_type: JointType = node
         .attribute("type")
-        .ok_or_else(|| format!("joint {} missing type attribute", name))?
-        .parse()
-        .map_err(|e| format!("joint {}: {}", name, e))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointType(name.clone()))?
+        .parse()?;
     let parent: String = node
         .children()
         .find(|n| n.tag_name().name() == "parent")
         .and_then(|n| n.attribute("link"))
-        .ok_or_else(|| format!("missing parent link for joint {}", name))?
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointParentLink(name.clone()))?
         .to_string();
     let child: String = node
         .children()
         .find(|n| n.tag_name().name() == "child")
         .and_then(|n| n.attribute("link"))
-        .ok_or_else(|| format!("missing child link for joint {}", name))?
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointChildLink(name.clone()))?
         .to_string();
 
     // Extracting joint XYZ and RPY
     let joint_origin = node
         .children()
         .find(|n| n.tag_name().name() == "origin")
-        .ok_or_else(|| format!("missing origin for joint {}", name))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlTagJointOrigin(name.clone()))?;
 
     let xyz_str: &str = joint_origin
         .attribute("xyz")
-        .ok_or_else(|| format!("missing xyz for joint {}", name))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointOriginXyz(name.clone()))?;
     let (x, y, z) = parse_vec3_str(xyz_str)?;
     let xyz = Vector3::new(x, y, z);
 
     let rpy_str = joint_origin
         .attribute("rpy")
-        .ok_or_else(|| format!("missing rpy for joint {}", name))?;
+        .ok_or_else(|| UrdfParseError::MissingXmlAttributeJointOriginRpy(name.clone()))?;
     let (roll, pitch, yaw) = parse_vec3_str(rpy_str)?;
     let rotation = UnitQuaternion::from_euler_angles(roll, pitch, yaw);
 
@@ -274,13 +275,15 @@ fn resolve_joint_order(
 /// After XML parsing, it resolves the joint order via Breadth-First Search (BFS)
 /// from the root so `compute_fk` can trust indices instead of file order.
 pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Error>> {
-    let content: String = fs::read_to_string(urdf_path)?;
-    let doc = roxmltree::Document::parse(&content)?;
+    let content: String = fs::read_to_string(urdf_path)
+        .map_err(|err| UrdfParseError::Io { path: urdf_path.to_string(), source: err })?;
+    let doc = roxmltree::Document::parse(&content)
+        .map_err(|err| UrdfParseError::XmlParse { xml_content: content.to_string(), source: err })?;
 
     let robot_name: String = doc
         .root_element()
         .attribute("name")
-        .ok_or("missing robot name")?
+        .ok_or(UrdfParseError::MissingXmlAttributeRobotName)?
         .to_string();
     let mut links: Vec<Link> = Vec::new();
     let mut joints: Vec<Joint> = Vec::new();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,6 @@ use std::fs;
 
 // Third-party
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
-use roxmltree::Node;
 
 // Custom
 use crate::error::{UrdfParseError};
@@ -40,14 +39,27 @@ fn read_joint_limits(
         .find(|n| n.tag_name().name() == "limit")
         .ok_or_else(|| UrdfParseError::MissingTagJointLimit(joint_name.to_string()))?;
 
-    let limit_lower: f64 = joint_limit
+    // Parsing lower joint limits
+    let limit_lower_str: &str = joint_limit
         .attribute("lower")
-        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitLower(joint_name.to_string()))?
-        .parse::<f64>()?;
-    let limit_upper: f64 = joint_limit
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitLower(joint_name.to_string()))?;
+    let limit_lower: f64 = limit_lower_str
+        .parse::<f64>()
+        .map_err(|source| UrdfParseError::InvalidNumberFormat { 
+            value: limit_lower_str.to_string(), 
+            source,
+    })?;
+
+    // Parsing upper joint limits
+    let limit_upper_str: &str = joint_limit
         .attribute("upper")
-        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitUpper(joint_name.to_string()))?
-        .parse::<f64>()?;
+        .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitUpper(joint_name.to_string()))?;
+    let limit_upper: f64 = limit_upper_str
+        .parse::<f64>()
+        .map_err(|source| UrdfParseError::InvalidNumberFormat { 
+            value: limit_upper_str.to_string(), 
+            source,
+    })?;
 
     Ok((limit_lower, limit_upper))
 }
@@ -70,7 +82,8 @@ fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::erro
     let joint_type: JointType = node
         .attribute("type")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointType(name.clone()))?
-        .parse()?;
+        .parse()
+        .map_err(|found| UrdfParseError::UnknownJointType { name: name.clone(), found })?;
 
     // Extracting parent info
     let joint_parent: roxmltree::Node<'_, '_> = node

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -170,8 +170,8 @@ fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, UrdfParseError> {
 }
 
 /// Visits the different nodes in DFS
-/// 
-/// If there is a link that has been revisited, it returns 
+///
+/// If there is a link that has been revisited, it returns
 /// the index of the link as an error to hint about cycles
 /// in kinematic model.
 fn dfs_visit(
@@ -237,8 +237,7 @@ fn dfs_visit(
 fn resolve_joint_order(
     links: &Vec<Link>,
     joints: &Vec<Joint>,
-) -> Result<(Vec<Joint>, HashMap<String, usize>, HashMap<String, usize>), ModelTopologyError>
-{
+) -> Result<(Vec<Joint>, HashMap<String, usize>, HashMap<String, usize>), ModelTopologyError> {
     // Enforcing order to ensure indexing is accurate
     let link_lookup: HashMap<&str, usize> = links
         .iter()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -323,7 +323,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, GalawError> {
         source: err,
     })?;
     let doc = roxmltree::Document::parse(&content).map_err(|err| UrdfParseError::XmlParse {
-        xml_content: content.to_string(),
+        path: urdf_path.to_string(),
         source: err,
     })?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,6 @@ use crate::error::{ModelTopologyError, UrdfParseError};
 use crate::types::{GalawModel, Joint, JointType, Link};
 use crate::utils::parse_vec3_str;
 
-
 // ----- HELPER METHODS -----
 /// Parses the axis information from tag
 fn read_axis(
@@ -43,23 +42,25 @@ fn read_joint_limits(
     let limit_lower_str: &str = joint_limit
         .attribute("lower")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitLower(joint_name.to_string()))?;
-    let limit_lower: f64 = limit_lower_str
-        .parse::<f64>()
-        .map_err(|source| UrdfParseError::InvalidNumberFormat { 
-            value: limit_lower_str.to_string(), 
-            source,
-    })?;
+    let limit_lower: f64 =
+        limit_lower_str
+            .parse::<f64>()
+            .map_err(|source| UrdfParseError::InvalidNumberFormat {
+                value: limit_lower_str.to_string(),
+                source,
+            })?;
 
     // Parsing upper joint limits
     let limit_upper_str: &str = joint_limit
         .attribute("upper")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointLimitUpper(joint_name.to_string()))?;
-    let limit_upper: f64 = limit_upper_str
-        .parse::<f64>()
-        .map_err(|source| UrdfParseError::InvalidNumberFormat { 
-            value: limit_upper_str.to_string(), 
-            source,
-    })?;
+    let limit_upper: f64 =
+        limit_upper_str
+            .parse::<f64>()
+            .map_err(|source| UrdfParseError::InvalidNumberFormat {
+                value: limit_upper_str.to_string(),
+                source,
+            })?;
 
     Ok((limit_lower, limit_upper))
 }
@@ -83,7 +84,10 @@ fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::erro
         .attribute("type")
         .ok_or_else(|| UrdfParseError::MissingAttributeJointType(name.clone()))?
         .parse()
-        .map_err(|found| UrdfParseError::UnknownJointType { name: name.clone(), found })?;
+        .map_err(|found| UrdfParseError::UnknownJointType {
+            name: name.clone(),
+            found,
+        })?;
 
     // Extracting parent info
     let joint_parent: roxmltree::Node<'_, '_> = node
@@ -180,7 +184,7 @@ fn dfs_visit(
         return Err(link_idx);
     }
 
-    // Retrive the link's children 
+    // Retrive the link's children
     let Some(child_joint_indices) = children_by_link.get(&link_idx) else {
         return Ok(());
     };
@@ -277,14 +281,12 @@ fn resolve_joint_order(
         &children_by_link,
         &mut ordered_joints,
         &mut acutated_joint_counter,
-        &mut visited
-    ).map_err(|err| ModelTopologyError::CyclicLink(links[err].name.clone()))?;
+        &mut visited,
+    )
+    .map_err(|err| ModelTopologyError::CyclicLink(links[err].name.clone()))?;
 
     // Find the disconnected joints
-    let visited_joints: HashSet<&str> = ordered_joints
-        .iter()
-        .map(|j| j.name.as_str())
-        .collect();
+    let visited_joints: HashSet<&str> = ordered_joints.iter().map(|j| j.name.as_str()).collect();
     let disconnected_joints: Vec<String> = joints
         .iter()
         .filter(|j| !visited_joints.contains(j.name.as_str()))
@@ -313,10 +315,14 @@ fn resolve_joint_order(
 /// After XML parsing, it resolves the joint order via Breadth-First Search (BFS)
 /// from the root so `compute_fk` can trust indices instead of file order.
 pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Error>> {
-    let content: String = fs::read_to_string(urdf_path)
-        .map_err(|err| UrdfParseError::Io { path: urdf_path.to_string(), source: err })?;
-    let doc = roxmltree::Document::parse(&content)
-        .map_err(|err| UrdfParseError::XmlParse { xml_content: content.to_string(), source: err })?;
+    let content: String = fs::read_to_string(urdf_path).map_err(|err| UrdfParseError::Io {
+        path: urdf_path.to_string(),
+        source: err,
+    })?;
+    let doc = roxmltree::Document::parse(&content).map_err(|err| UrdfParseError::XmlParse {
+        xml_content: content.to_string(),
+        source: err,
+    })?;
 
     let robot_name: String = doc
         .root_element()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use std::fs;
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
 
 // Custom
-use crate::error::{ModelTopologyError, UrdfParseError};
+use crate::error::{GalawError, ModelTopologyError, UrdfParseError};
 use crate::types::{GalawModel, Joint, JointType, Link};
 use crate::utils::parse_vec3_str;
 
@@ -14,7 +14,7 @@ use crate::utils::parse_vec3_str;
 fn read_axis(
     node: roxmltree::Node<'_, '_>,
     joint_name: &str,
-) -> Result<Unit<Vector3<f64>>, Box<dyn std::error::Error>> {
+) -> Result<Unit<Vector3<f64>>, UrdfParseError> {
     // Extracting axis angles
     let axis_str: &str = node
         .children()
@@ -32,7 +32,7 @@ fn read_axis(
 fn read_joint_limits(
     node: roxmltree::Node<'_, '_>,
     joint_name: &str,
-) -> Result<(f64, f64), Box<dyn std::error::Error>> {
+) -> Result<(f64, f64), UrdfParseError> {
     let joint_limit = node
         .children()
         .find(|n| n.tag_name().name() == "limit")
@@ -66,7 +66,7 @@ fn read_joint_limits(
 }
 
 /// Parses <link> tag into a `Link`
-fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error::Error>> {
+fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, UrdfParseError> {
     let link_name: String = node
         .attribute("name")
         .ok_or(UrdfParseError::MissingAttributeLinkName)?
@@ -75,7 +75,7 @@ fn parse_link(node: roxmltree::Node<'_, '_>) -> Result<Link, Box<dyn std::error:
 }
 
 /// Parses <joint> tag into a `Joint`
-fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::error::Error>> {
+fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, UrdfParseError> {
     let name: String = node
         .attribute("name")
         .ok_or(UrdfParseError::MissingAttributeJointName)?
@@ -170,6 +170,10 @@ fn parse_joint(node: roxmltree::Node<'_, '_>) -> Result<Joint, Box<dyn std::erro
 }
 
 /// Visits the different nodes in DFS
+/// 
+/// If there is a link that has been revisited, it returns 
+/// the index of the link as an error to hint about cycles
+/// in kinematic model.
 fn dfs_visit(
     link_idx: usize,
     joints: &[Joint],
@@ -233,7 +237,7 @@ fn dfs_visit(
 fn resolve_joint_order(
     links: &Vec<Link>,
     joints: &Vec<Joint>,
-) -> Result<(Vec<Joint>, HashMap<String, usize>, HashMap<String, usize>), Box<dyn std::error::Error>>
+) -> Result<(Vec<Joint>, HashMap<String, usize>, HashMap<String, usize>), ModelTopologyError>
 {
     // Enforcing order to ensure indexing is accurate
     let link_lookup: HashMap<&str, usize> = links
@@ -314,7 +318,7 @@ fn resolve_joint_order(
 ///
 /// After XML parsing, it resolves the joint order via Breadth-First Search (BFS)
 /// from the root so `compute_fk` can trust indices instead of file order.
-pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, Box<dyn std::error::Error>> {
+pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, GalawError> {
     let content: String = fs::read_to_string(urdf_path).map_err(|err| UrdfParseError::Io {
         path: urdf_path.to_string(),
         source: err,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -417,4 +417,50 @@ mod tests {
             );
         }
     }
+
+    /// Creates graph ROOT -> A -> B -> A. This ensures that dfs_visit
+    /// does not have unbounded recursion error.
+    #[test]
+    fn resolve_joint_order_detects_reachable_cycle() {
+        fn joint(name: &str, parent: &str, child: &str) -> Joint {
+            Joint {
+                name: name.to_string(),
+                joint_type: JointType::Fixed,
+                parent: parent.to_string(),
+                parent_link_idx: 0,
+                child: child.to_string(),
+                child_link_idx: 0,
+                transform: Isometry3::identity(),
+                lin_axis: None,
+                rot_axis: None,
+                limit_lower: None,
+                limit_upper: None,
+                cmd_idx: None,
+            }
+        }
+
+        let links = vec![
+            Link {
+                name: "ROOT".to_string(),
+            },
+            Link {
+                name: "A".to_string(),
+            },
+            Link {
+                name: "B".to_string(),
+            },
+        ];
+        let joints = vec![
+            joint("j1", "ROOT", "A"),
+            joint("j2", "A", "B"),
+            joint("j3", "B", "A"), // closes the cycle back to A
+        ];
+
+        let result = resolve_joint_order(&links, &joints);
+
+        assert!(
+            matches!(&result, Err(ModelTopologyError::CyclicLink(name)) if name == "A"),
+            "expected CyclicLink(\"A\"), got {result:?}"
+        );
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use std::fs;
 use nalgebra::{Isometry3, Translation3, Unit, UnitQuaternion, Vector3};
 
 // Custom
-use crate::error::{UrdfParseError};
+use crate::error::{ModelTopologyError, UrdfParseError};
 use crate::types::{GalawModel, Joint, JointType, Link};
 use crate::utils::parse_vec3_str;
 
@@ -246,17 +246,13 @@ fn resolve_joint_order(
         .collect();
     let root_idx = match root_candidates.as_slice() {
         [single] => *single,
-        [] => return Err("no root link found - every link has a parent (cycle in URDF?)".into()),
+        [] => return Err(ModelTopologyError::MissingRootLink.into()),
         _ => {
-            let names: Vec<&str> = root_candidates
+            let names: Vec<String> = root_candidates
                 .iter()
-                .map(|&i| links[i].name.as_str())
+                .map(|&i| links[i].name.clone())
                 .collect();
-            return Err(format!(
-                "multiple root-like links with no parent: {:?} - URDF may be disconnected",
-                names
-            )
-            .into());
+            return Err(ModelTopologyError::MultipleRootLinks(names).into());
         }
     };
 
@@ -273,9 +269,7 @@ fn resolve_joint_order(
     );
 
     if ordered_joints.len() != joints.len() {
-        return Err(
-            "some joints are unreachable from root link (disconnected or cyclic URDF)".into(),
-        );
+        return Err(ModelTopologyError::DisconnectedOrCyclicJoints.into());
     }
 
     let link_name_to_idx: HashMap<String, usize> = links

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -173,9 +173,16 @@ fn dfs_visit(
     children_by_link: &HashMap<usize, Vec<usize>>,
     ordered_joints: &mut Vec<Joint>,
     cmd_counter: &mut usize,
-) {
+    visited: &mut HashSet<usize>,
+) -> Result<(), usize> {
+    // Checks if we visited before
+    if !visited.insert(link_idx) {
+        return Err(link_idx);
+    }
+
+    // Retrive the link's children 
     let Some(child_joint_indices) = children_by_link.get(&link_idx) else {
-        return;
+        return Ok(());
     };
 
     for &joint_idx in child_joint_indices {
@@ -201,8 +208,11 @@ fn dfs_visit(
             children_by_link,
             ordered_joints,
             cmd_counter,
-        );
+            visited,
+        )?;
     }
+
+    Ok(())
 }
 
 /// Resolves joint order for downstream functions.
@@ -259,6 +269,7 @@ fn resolve_joint_order(
     // Walk the tree from root, resolving parent/child link indices
     let mut ordered_joints: Vec<Joint> = Vec::with_capacity(joints.len());
     let mut acutated_joint_counter = 0;
+    let mut visited: HashSet<usize> = HashSet::new();
     dfs_visit(
         root_idx,
         joints,
@@ -266,10 +277,21 @@ fn resolve_joint_order(
         &children_by_link,
         &mut ordered_joints,
         &mut acutated_joint_counter,
-    );
+        &mut visited
+    ).map_err(|err| ModelTopologyError::CyclicLink(links[err].name.clone()))?;
 
-    if ordered_joints.len() != joints.len() {
-        return Err(ModelTopologyError::DisconnectedOrCyclicJoints.into());
+    // Find the disconnected joints
+    let visited_joints: HashSet<&str> = ordered_joints
+        .iter()
+        .map(|j| j.name.as_str())
+        .collect();
+    let disconnected_joints: Vec<String> = joints
+        .iter()
+        .filter(|j| !visited_joints.contains(j.name.as_str()))
+        .map(|j| j.name.clone())
+        .collect();
+    if !disconnected_joints.is_empty() {
+        return Err(ModelTopologyError::DisconnectedJoints(disconnected_joints).into());
     }
 
     let link_name_to_idx: HashMap<String, usize> = links

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,7 +25,7 @@ impl std::str::FromStr for JointType {
             "prismatic" => Ok(JointType::Prismatic),
             "fixed" => Ok(JointType::Fixed),
             "continuous" => Ok(JointType::Continuous),
-            other => Err(format!("unknown joint type: {other}")),
+            other => Err(other.to_string()),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,18 @@
+// Custom
+use crate::error::UrdfParseError;
+
 pub fn parse_vec3_str(input_str: &str) -> Result<(f64, f64, f64), Box<dyn std::error::Error>> {
     // Parses and extracts values from string. Assumes will contain 3 values.
     let vals: Vec<f64> = input_str
         .split_whitespace()
-        .map(|n| n.parse::<f64>())
+        .map(|n| {
+            n.parse::<f64>()
+                .map_err(|source| UrdfParseError::InvalidNumberFormat { value: n.to_string(), source })
+        })
         .collect::<Result<Vec<f64>, _>>()?;
 
     if vals.len() != 3 {
-        return Err("expected exactly 3 values".into());
+        return Err(UrdfParseError::InvalidVector3Len(input_str.to_string(), vals.len()).into());
     }
 
     Ok((vals[0], vals[1], vals[2]))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,10 @@ pub fn parse_vec3_str(input_str: &str) -> Result<(f64, f64, f64), Box<dyn std::e
         .split_whitespace()
         .map(|n| {
             n.parse::<f64>()
-                .map_err(|source| UrdfParseError::InvalidNumberFormat { value: n.to_string(), source })
+                .map_err(|source| UrdfParseError::InvalidNumberFormat {
+                    value: n.to_string(),
+                    source,
+                })
         })
         .collect::<Result<Vec<f64>, _>>()?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 // Custom
 use crate::error::UrdfParseError;
 
-pub fn parse_vec3_str(input_str: &str) -> Result<(f64, f64, f64), Box<dyn std::error::Error>> {
+pub fn parse_vec3_str(input_str: &str) -> Result<(f64, f64, f64), UrdfParseError> {
     // Parses and extracts values from string. Assumes will contain 3 values.
     let vals: Vec<f64> = input_str
         .split_whitespace()


### PR DESCRIPTION
# Features
- Created `error.rs` to create a structured, matchable error heirarchy (`UrdfParseError`, `ModelTopologyError`, `KinematicsError`, under the umbrella of `GalawError`). 
- Replaced `Box<dyn Error>` and string-built errors with ones defined under `GalawError`. 
- Fixed bug with dfs_visit logic to include checking visited links to prevent stack-overflow crash. Raises a `ModelTopologyError::CyclicLink`. Created test for this in `parser.rs`. 