### PR TITLE
feat: compute ik

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ harness = false
 [[bench]]
 name = "jacobian_speed"
 harness = false
+
+[[bench]]
+name = "ik_speed"
+harness = false

--- a/benches/ik_speed.rs
+++ b/benches/ik_speed.rs
@@ -1,0 +1,113 @@
+use std::collections::HashSet;
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use k::InverseKinematicsSolver;
+use rand::{RngExt, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use galaw::{fixtures::BENCH_URDFS, load_urdf, types::GalawModel};
+
+const RNG_SEED: u64 = 42;
+const N_POSES: usize = 100;
+const MAX_PERTURBATION: f64 = 0.5;
+
+fn random_joint_cmds(model: &GalawModel, rng: &mut ChaCha8Rng) -> Vec<f64> {
+    model
+        .joints
+        .iter()
+        .filter(|j| j.cmd_idx.is_some())
+        .map(|j| match (j.limit_lower, j.limit_upper) {
+            (Some(lo), Some(hi)) => rng.random_range(lo..hi),
+            _ => rng.random_range(0.0..0.0),
+        })
+        .collect()
+}
+
+fn perturbed_joint_cmds(model: &GalawModel, base: &[f64], rng: &mut ChaCha8Rng) -> Vec<f64> {
+    model
+        .joints
+        .iter()
+        .filter(|j| j.cmd_idx.is_some())
+        .zip(base)
+        .map(|(j, &v)| {
+            let p = v + rng.random_range(-MAX_PERTURBATION..MAX_PERTURBATION);
+            match (j.limit_lower, j.limit_upper) {
+                (Some(lo), Some(hi)) => p.clamp(lo, hi),
+                _ => p,
+            }
+        })
+        .collect()
+}
+
+// First leaf link with an actuated ancestor.
+fn target_link(model: &GalawModel) -> usize {
+    let parents: HashSet<usize> = model.joints.iter().map(|j| j.parent_link_idx).collect();
+    let mut has_actuated_ancestor = vec![false; model.links.len()];
+    for joint in &model.joints {
+        has_actuated_ancestor[joint.child_link_idx] =
+            has_actuated_ancestor[joint.parent_link_idx] || joint.cmd_idx.is_some();
+    }
+    (0..model.links.len())
+        .find(|&i| !parents.contains(&i) && has_actuated_ancestor[i])
+        .unwrap()
+}
+
+fn bench_ik(c: &mut Criterion) {
+    for &urdf_path in BENCH_URDFS {
+        let galaw_model = load_urdf(urdf_path).unwrap();
+        let k_chain = k::Chain::<f64>::from_urdf_file(urdf_path).unwrap();
+        let link_idx = target_link(&galaw_model);
+        let link_name = &galaw_model.links[link_idx].name;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
+        let trials: Vec<(Vec<f64>, Vec<f64>)> = (0..N_POSES)
+            .map(|_| {
+                let target = random_joint_cmds(&galaw_model, &mut rng);
+                let init = perturbed_joint_cmds(&galaw_model, &target, &mut rng);
+                (target, init)
+            })
+            .collect();
+
+        let mut group = c.benchmark_group(format!("ik/{}", galaw_model.name));
+        group.throughput(criterion::Throughput::Elements(trials.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("galaw-runtime", galaw_model.joints.len()),
+            &trials,
+            |b, trials| {
+                b.iter(|| {
+                    for (target, init) in trials {
+                        let pose = galaw_model.compute_fk(target).unwrap()[link_idx];
+                        let _ = black_box(galaw_model.compute_ik(link_idx, &pose, black_box(init)));
+                    }
+                });
+            },
+        );
+
+        let solver = k::JacobianIkSolver::new(1e-4, 1e-4, 1.0, 1000);
+        group.bench_with_input(
+            BenchmarkId::new("k", galaw_model.joints.len()),
+            &trials,
+            |b, trials| {
+                b.iter(|| {
+                    for (target, init) in trials {
+                        k_chain.set_joint_positions(target).unwrap();
+                        k_chain.update_transforms();
+                        let pose = k_chain.find_link(link_name).unwrap().world_transform().unwrap();
+
+                        k_chain.set_joint_positions(black_box(init)).unwrap();
+                        k_chain.update_transforms();
+                        let serial = k::SerialChain::from_end(k_chain.find_link(link_name).unwrap());
+                        let _ = black_box(solver.solve(&serial, &pose));
+                    }
+                });
+            },
+        );
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_ik);
+criterion_main!(benches);

--- a/benches/ik_speed.rs
+++ b/benches/ik_speed.rs
@@ -94,11 +94,16 @@ fn bench_ik(c: &mut Criterion) {
                     for (target, init) in trials {
                         k_chain.set_joint_positions(target).unwrap();
                         k_chain.update_transforms();
-                        let pose = k_chain.find_link(link_name).unwrap().world_transform().unwrap();
+                        let pose = k_chain
+                            .find_link(link_name)
+                            .unwrap()
+                            .world_transform()
+                            .unwrap();
 
                         k_chain.set_joint_positions(black_box(init)).unwrap();
                         k_chain.update_transforms();
-                        let serial = k::SerialChain::from_end(k_chain.find_link(link_name).unwrap());
+                        let serial =
+                            k::SerialChain::from_end(k_chain.find_link(link_name).unwrap());
                         let _ = black_box(solver.solve(&serial, &pose));
                     }
                 });

--- a/benches/jacobian_speed.rs
+++ b/benches/jacobian_speed.rs
@@ -15,12 +15,12 @@ use galaw::{fixtures::BENCH_URDFS, load_urdf};
 const RNG_SEED: u64 = 42;
 const N_POSES: usize = 100;
 
-/// Benchmarks a codegen'd `compute_jacobian` under the "galaw-generated" id.
+/// Benchmarks a codegen'd `compute_link_jacobians` under the "galaw-generated" id.
 fn bench_generated_jacobian<const N: usize, const M: usize>(
     group: &mut BenchmarkGroup<'_, WallTime>,
     bench_id: usize,
     joint_cmds: &[Vec<f64>],
-    generated_compute_jacobian: impl Fn(&[f64; N]) -> [SMatrix<f64, 6, N>; M],
+    generated_compute_link_jacobians: impl Fn(&[f64; N]) -> [SMatrix<f64, 6, N>; M],
 ) {
     // Conversion to fixed-size arrays happens once, up front - not timed.
     let joint_cmds_arr: Vec<[f64; N]> = joint_cmds
@@ -34,7 +34,7 @@ fn bench_generated_jacobian<const N: usize, const M: usize>(
         |b, cmds| {
             b.iter(|| {
                 for cmd in cmds {
-                    let out = generated_compute_jacobian(black_box(cmd));
+                    let out = generated_compute_link_jacobians(black_box(cmd));
                     black_box(out);
                 }
             });
@@ -74,7 +74,7 @@ fn bench_jacobian(c: &mut Criterion) {
             |b, cmds| {
                 b.iter(|| {
                     for cmd in cmds {
-                        let out = galaw_model.compute_jacobian(black_box(cmd)).unwrap();
+                        let out = galaw_model.compute_link_jacobians(black_box(cmd)).unwrap();
                         black_box(out);
                     }
                 });
@@ -90,7 +90,7 @@ fn bench_jacobian(c: &mut Criterion) {
                         &mut group,
                         galaw_model.joints.len(),
                         &joint_cmds,
-                        galaw::generated::$module::compute_jacobian,
+                        galaw::generated::$module::compute_link_jacobians,
                     );
                     generated_bench_registered = true;
                 }
@@ -99,7 +99,7 @@ fn bench_jacobian(c: &mut Criterion) {
         galaw::for_each_generated_robot!(bench_if_matches);
         assert!(
             generated_bench_registered,
-            "no generated compute_jacobian registered for {urdf_path} — run scripts/codegen_all_urdfs.sh"
+            "no generated compute_link_jacobians registered for {urdf_path} — run scripts/codegen_all_urdfs.sh"
         );
 
         // ---- k ----

--- a/examples/generated_jacobian.rs
+++ b/examples/generated_jacobian.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), GalawError> {
     let forearm_idx = model
         .get_link_idx("forearm")
         .expect("forearm link exists in URDF");
-    let jacobian = simple_arm_2dof::compute_jacobian(&joint_cmds);
+    let jacobian = simple_arm_2dof::compute_link_jacobians(&joint_cmds);
 
     println!("jacobian:\n{}", jacobian[forearm_idx]);
 

--- a/examples/plot_ik_bench.rs
+++ b/examples/plot_ik_bench.rs
@@ -1,0 +1,320 @@
+//! Renders IK benchmark charts from Criterion's JSON output using
+//! `charming` (Apache ECharts bindings). Reads each benchmark's `estimates.json`
+//! so the charts stay in sync with the latest `cargo bench --bench ik_speed` run.
+//!
+//! Each chart is a line-over-DOF plot per implementation, showing:
+//!   * the mean per-call time/throughput (with the value printed as a label), and
+//!   * a shaded 95% confidence-interval band (ECharts has no native error bars;
+//!     the band is drawn as a stacked area between the CI's lower and upper bounds).
+//!
+//! Usage (after `cargo bench --bench ik_speed`):
+//!     cargo run --release --example plot_ik_bench
+//!
+//! Output PNGs land in docs/bench/. Requires dev-deps `charming` (feature
+//! "ssr-raster") and `serde_json`. The first build is slow: charming's `ssr`
+//! feature bundles a JS engine (deno_core) to render ECharts server-side.
+
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+// Third-party
+use charming::component::{Axis, Grid, Legend, Title};
+use charming::element::{
+    AreaStyle, AxisLabel, AxisType, ItemStyle, Label, LabelPosition, LineStyle, NameLocation,
+    TextStyle,
+};
+use charming::series::Line;
+use charming::{Chart, ImageFormat, ImageRenderer};
+
+// Custom
+use galaw::{fixtures::BENCH_URDFS, load_urdf};
+
+/// Calls per timed iteration in benches/ik_speed.rs. Criterion's estimates
+/// are per iteration, so dividing by this converts to per single `compute_ik` call.
+const N_POSES: f64 = 100.0;
+
+/// No codegen counterpart for IK (see docs on `compute_ik`) — only the
+/// runtime solver and `k`'s own Jacobian IK solver are benchmarked.
+const IMPLS: [&str; 2] = ["galaw-runtime", "k"];
+
+/// Wong (2011) colorblind-safe pair: galaw-runtime=blue, k=orange.
+const COLORS: [&str; 2] = ["#0072B2", "#E69F00"];
+
+// ----- FONT SIZES (tweak here — every chart text element is driven off these) -----
+const TITLE_FONT_SIZE: f64 = 38.0;
+const LEGEND_FONT_SIZE: f64 = 20.0;
+/// Shared by both axes' `name` (the "Robot [...]" / "ns per call" labels).
+const AXIS_NAME_FONT_SIZE: f64 = 22.0;
+/// Shared by both axes' tick labels (the numbers/categories along each axis).
+const AXIS_TICK_FONT_SIZE: f64 = 19.0;
+
+/// Approx. rendered height (px) of one data-point label box at LABEL_FONT_SIZE
+/// (text line-height + the label's own padding/border) — used to stagger each
+/// series' label distance from its point by index, so two series' labels can
+/// never collide even if their points land at the same y-pixel. Scales to
+/// however many entries IMPLS has; no per-series manual tuning needed.
+/// Keep this in sync with LABEL_FONT_SIZE — it's sized for the box height
+/// *at that font size*, not computed from it.
+const LABEL_FONT_SIZE: f64 = 19.0;
+const LABEL_STAGGER_PX: f64 = 16.0;
+
+/// Mean and 95% CI bounds for a single benchmark, in ns per `compute_ik` call.
+struct Stat {
+    mean: f64,
+    lo: f64,
+    hi: f64,
+}
+
+struct RobotInfo {
+    name: String, // matches galaw_model.name, for the x-axis label
+    group: String,
+    bench_id: u32, // matches galaw_model.joints.len()
+    dof: u32,      // matches galaw_model.num_actuated_joints
+}
+
+// ----- HELPER METHODS -----
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn robot_info(urdf_path: &str) -> Result<RobotInfo, Box<dyn Error>> {
+    let model = load_urdf(urdf_path)?;
+    Ok(RobotInfo {
+        name: model.name.clone(),
+        group: format!("ik_{}", model.name),
+        bench_id: model.joints.len() as u32,
+        dof: model.num_actuated_joints as u32,
+    })
+}
+
+/// Reads mean + confidence interval (ns per call) from Criterion's estimates.json.
+fn stat(group: &str, impl_: &str, dof: u32) -> Result<Stat, Box<dyn Error>> {
+    let path = manifest_dir()
+        .join("target/criterion")
+        .join(group)
+        .join(impl_)
+        .join(dof.to_string())
+        .join("new/estimates.json");
+
+    let text = fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "could not read {} (run `cargo bench --bench ik_speed` first): {e}",
+            path.display()
+        )
+    })?;
+    let v: serde_json::Value = serde_json::from_str(&text)?;
+    let mean = &v["mean"];
+    let field = |ptr: &serde_json::Value, key: &str| -> Result<f64, Box<dyn Error>> {
+        Ok(ptr[key]
+            .as_f64()
+            .ok_or_else(|| format!("estimates.json: missing {key}"))?
+            / N_POSES)
+    };
+
+    Ok(Stat {
+        mean: field(mean, "point_estimate")?,
+        lo: field(&mean["confidence_interval"], "lower_bound")?,
+        hi: field(&mean["confidence_interval"], "upper_bound")?,
+    })
+}
+
+/// Builds a line chart over DOF with a mean line + labels and a CI band per impl.
+fn build_chart(
+    robots: &[RobotInfo],
+    title: &str,
+    y_name: &str,
+    to_vals: impl Fn(&Stat) -> (f64, f64, f64),
+    round: impl Fn(f64) -> f64,
+) -> Result<Chart, Box<dyn Error>> {
+    let dof_labels: Vec<String> = robots
+        .iter()
+        .map(|r| format!("{}\n[{}/{}]", r.name, r.bench_id, r.dof))
+        .collect();
+
+    let mut chart = Chart::new()
+        .background_color("#ffffff")
+        .title(
+            Title::new()
+                .text(title)
+                .left("center")
+                .text_style(TextStyle::new().font_size(TITLE_FONT_SIZE)),
+        )
+        .legend(
+            Legend::new()
+                .top("bottom")
+                .text_style(TextStyle::new().font_size(LEGEND_FONT_SIZE))
+                .item_gap(LEGEND_FONT_SIZE * 2.0)
+                .width("90%")
+                .data(IMPLS.to_vec()),
+        )
+        .grid(
+            Grid::new()
+                .left("4%")
+                .right("4%")
+                .top("12%")
+                .bottom(170)
+                .contain_label(true),
+        )
+        .x_axis(
+            Axis::new()
+                .type_(AxisType::Category)
+                .name("Robot [total joints / actuated joints]")
+                .name_location(NameLocation::Middle)
+                .name_gap(85.0)
+                .name_text_style(TextStyle::new().font_size(AXIS_NAME_FONT_SIZE))
+                .axis_label(
+                    AxisLabel::new()
+                        .font_size(AXIS_TICK_FONT_SIZE)
+                        .interval(0.0),
+                )
+                .data(dof_labels),
+        )
+        .y_axis(
+            Axis::new()
+                .type_(AxisType::Log)
+                .log_base(10.0)
+                .name(y_name)
+                .name_location(NameLocation::Middle)
+                .name_gap(70.0)
+                .name_text_style(TextStyle::new().font_size(AXIS_NAME_FONT_SIZE))
+                .axis_label(AxisLabel::new().font_size(AXIS_TICK_FONT_SIZE)),
+        );
+
+    struct SeriesData {
+        impl_: &'static str,
+        color: &'static str,
+        means: Vec<f64>,
+        los: Vec<f64>,
+        heights: Vec<f64>,
+        typical: f64,
+    }
+    let mut all_series: Vec<SeriesData> = Vec::new();
+    for (&impl_, &color) in IMPLS.iter().zip(COLORS.iter()) {
+        let (mut means, mut los, mut heights) = (Vec::new(), Vec::new(), Vec::new());
+        for robot in robots {
+            let (m, lo, hi) = to_vals(&stat(&robot.group, impl_, robot.bench_id)?);
+            means.push(round(m));
+            los.push(lo);
+            heights.push(hi - lo);
+        }
+        let mut sorted_means = means.clone();
+        sorted_means.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let typical = sorted_means[sorted_means.len() / 2];
+        all_series.push(SeriesData {
+            impl_,
+            color,
+            means,
+            los,
+            heights,
+            typical,
+        });
+    }
+
+    let mut rank_order: Vec<usize> = (0..all_series.len()).collect();
+    rank_order.sort_by(|&a, &b| {
+        all_series[a]
+            .typical
+            .partial_cmp(&all_series[b].typical)
+            .unwrap()
+    });
+    let mut stagger_rank = vec![0usize; all_series.len()];
+    for (rank, &series_idx) in rank_order.iter().enumerate() {
+        stagger_rank[series_idx] = rank;
+    }
+
+    for (i, series) in all_series.into_iter().enumerate() {
+        let SeriesData {
+            impl_,
+            color,
+            means,
+            los,
+            heights,
+            ..
+        } = series;
+        let label_pos = LabelPosition::Top;
+        let label_distance = 4.0 + stagger_rank[i] as f64 * LABEL_STAGGER_PX;
+
+        let stack_id = format!("band_{impl_}");
+        chart = chart.series(
+            Line::new()
+                .stack(stack_id.clone())
+                .show_symbol(false)
+                .line_style(LineStyle::new().opacity(0.0))
+                .data(los),
+        );
+        chart = chart.series(
+            Line::new()
+                .stack(stack_id)
+                .show_symbol(false)
+                .line_style(LineStyle::new().opacity(0.0))
+                .area_style(AreaStyle::new().color(color).opacity(0.18))
+                .data(heights),
+        );
+        chart = chart.series(
+            Line::new()
+                .name(impl_)
+                .line_style(LineStyle::new().color(color).width(2.0))
+                .item_style(ItemStyle::new().color(color))
+                .label(
+                    Label::new()
+                        .show(true)
+                        .position(label_pos)
+                        .distance(label_distance)
+                        .font_size(LABEL_FONT_SIZE)
+                        .color(color)
+                        .background_color("#ffffff")
+                        .border_color(color)
+                        .border_width(1.0)
+                        .padding((4.0, 8.0, 4.0, 8.0)),
+                )
+                .data(means),
+        );
+    }
+    Ok(chart)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut robots: Vec<RobotInfo> = BENCH_URDFS
+        .iter()
+        .map(|&p| robot_info(p))
+        .collect::<Result<_, _>>()?;
+    robots.sort_by_key(|r| r.dof);
+
+    let out = manifest_dir().join("docs/bench");
+    fs::create_dir_all(&out)?;
+    let mut renderer = ImageRenderer::new(1600, 900);
+
+    let latency = build_chart(
+        &robots,
+        "IK latency scaling (95% CI)",
+        "ns per call (lower is better)",
+        |s| (s.mean, s.lo, s.hi),
+        |x| x.round(),
+    )?;
+    let p1 = out.join("ik_scaling_ns_per_call.png");
+    renderer.save_format(
+        ImageFormat::Png,
+        &latency,
+        p1.to_str().ok_or("non-utf8 path")?,
+    )?;
+    println!("wrote {}", p1.display());
+
+    let mcps = |ns: f64| 1e9 / ns / 1e6;
+    let throughput = build_chart(
+        &robots,
+        "IK throughput (95% CI)",
+        "million calls/sec (higher is better)",
+        move |s| (mcps(s.mean), mcps(s.hi), mcps(s.lo)),
+        |x| (x * 100.0).round() / 100.0,
+    )?;
+    let p2 = out.join("ik_throughput_mcalls.png");
+    renderer.save_format(
+        ImageFormat::Png,
+        &throughput,
+        p2.to_str().ok_or("non-utf8 path")?,
+    )?;
+    println!("wrote {}", p2.display());
+
+    Ok(())
+}

--- a/examples/plot_jacobian_bench.rs
+++ b/examples/plot_jacobian_bench.rs
@@ -31,7 +31,7 @@ use charming::{Chart, ImageFormat, ImageRenderer};
 use galaw::{fixtures::BENCH_URDFS, load_urdf};
 
 /// Calls per timed iteration in benches/jacobian_speed.rs. Criterion's estimates
-/// are per iteration, so dividing by this converts to per single `compute_jacobian` call.
+/// are per iteration, so dividing by this converts to per single `compute_link_jacobians` call.
 const N_POSES: f64 = 100.0;
 
 const IMPLS: [&str; 3] = ["galaw-runtime", "galaw-generated", "k"];
@@ -57,7 +57,7 @@ const AXIS_TICK_FONT_SIZE: f64 = 19.0;
 const LABEL_FONT_SIZE: f64 = 19.0;
 const LABEL_STAGGER_PX: f64 = 16.0;
 
-/// Mean and 95% CI bounds for a single benchmark, in ns per `compute_jacobian` call.
+/// Mean and 95% CI bounds for a single benchmark, in ns per `compute_link_jacobians` call.
 struct Stat {
     mean: f64,
     lo: f64,

--- a/examples/runtime_ik.rs
+++ b/examples/runtime_ik.rs
@@ -1,0 +1,33 @@
+use galaw::{error::GalawError, load_urdf, types::GalawModel};
+
+fn main() -> Result<(), GalawError> {
+    let model: GalawModel = load_urdf("assets/urdf/custom/simple_arm_2dof.urdf")?;
+
+    let shoulder_joint_idx = model
+        .get_joint_idx("shoulder_joint")
+        .expect("shoulder_joint exists in URDF");
+    let elbow_joint_idx = model
+        .get_joint_idx("elbow_joint")
+        .expect("elbow_joint exists in URDF");
+    let forearm_link_idx = model
+        .get_link_idx("forearm")
+        .expect("forearm link exists in URDF");
+
+    // Known solution
+    let mut known_joint_cmds = vec![0.0; model.num_actuated_joints];
+    known_joint_cmds[shoulder_joint_idx] = 0.5;
+    known_joint_cmds[elbow_joint_idx] = -0.3;
+    let target_pose = model.compute_fk(&known_joint_cmds)?[forearm_link_idx];
+
+    // Start IK from different guess
+    let init_joint_cmds = vec![0.0; model.num_actuated_joints];
+    let solved_joint_cmds = model.compute_ik(forearm_link_idx, &target_pose, &init_joint_cmds)?;
+
+    let solved_pose = model.compute_fk(&solved_joint_cmds)?[forearm_link_idx];
+
+    println!("target_pose: {:?}", target_pose);
+    println!("solved cmds: {:?}", solved_joint_cmds);
+    println!("solved pose: {:?}", solved_pose);
+
+    Ok(())
+}

--- a/examples/runtime_jacobian.rs
+++ b/examples/runtime_jacobian.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), GalawError> {
     let forearm_idx = model
         .get_link_idx("forearm")
         .expect("forearm link exists in URDF");
-    let jacobian = model.compute_jacobian(&joint_cmds)?;
+    let jacobian = model.compute_link_jacobians(&joint_cmds)?;
 
     println!("jacobian:\n{}", jacobian[forearm_idx]);
 

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -238,7 +238,7 @@ fn generate_jacobian_fn_code(
 
     // function signature
     codegen_output.push(format!(
-        "pub fn compute_jacobian(joint_cmds: &[f64; {}]) -> [SMatrix<f64, 6, {}>; {}] {{",
+        "pub fn compute_link_jacobians(joint_cmds: &[f64; {}]) -> [SMatrix<f64, 6, {}>; {}] {{",
         galaw_model.num_actuated_joints,
         galaw_model.num_actuated_joints,
         galaw_model.links.len(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,4 +146,12 @@ pub enum KinematicsError {
         /// Number of joint commands actually given.
         num_input: usize,
     },
+    /// IK failed to converge
+    #[error("ik didnot not converge within {iterations} iterations. final error: {final_error}")] 
+    IkDidNotConverge {
+        /// Number of iterations
+        iterations: usize,
+        /// Final error of iterations
+        final_error: f64,
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,11 +155,11 @@ pub enum KinematicsError {
         requested: usize,
     },
     /// IK failed to converge
-    #[error("ik didnot not converge within {iterations} iterations. final error: {final_error}")] 
+    #[error("ik didnot not converge within {iterations} iterations. final error: {final_error}")]
     IkDidNotConverge {
         /// Number of iterations
         iterations: usize,
         /// Final error of iterations
         final_error: f64,
-    }
+    },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,14 @@ pub enum KinematicsError {
         /// Number of joint commands actually given.
         num_input: usize,
     },
+    /// `target_link_idx` is out of range for this model's links.
+    #[error("model has {num_links} links, requested index {requested}")]
+    LinkIdxOutOfBounds {
+        /// Number of links in the model.
+        num_links: usize,
+        /// The out-of-range index that was requested.
+        requested: usize,
+    },
     /// IK failed to converge
     #[error("ik didnot not converge within {iterations} iterations. final error: {final_error}")] 
     IkDidNotConverge {

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -110,7 +110,7 @@ let link_inspection_payload_camera_default = link_inspection_payload_mount * Tra
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 14]) -> [SMatrix<f64, 6, 14>; 96] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 14]) -> [SMatrix<f64, 6, 14>; 96] {
 let links = compute_fk(joint_cmds);
 let axis_world_43 = links[44].rotation * Vector3::new(1.0, 0.0, 0.0);
 let axis_world_46 = links[48].rotation * Vector3::new(-1.0, 0.0, 0.0);

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -24,7 +24,7 @@ let link_flange = link_link7 * Translation3::new(0.0, 0.0, 0.048);
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 7]) -> [SMatrix<f64, 6, 7>; 10] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 7]) -> [SMatrix<f64, 6, 7>; 10] {
 let links = compute_fk(joint_cmds);
 let axis_world_1 = links[2].rotation * Vector3::new(0.0, 0.0, 1.0);
 let axis_world_2 = links[3].rotation * Vector3::new(0.0, 0.0, 1.0);

--- a/src/generated/simple_arm_2dof.rs
+++ b/src/generated/simple_arm_2dof.rs
@@ -17,7 +17,7 @@ let link_forearm = link_upper_arm * Translation3::new(0.0, 0.0, 0.9) * { let (s,
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 2]) -> [SMatrix<f64, 6, 2>; 3] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 2]) -> [SMatrix<f64, 6, 2>; 3] {
 let links = compute_fk(joint_cmds);
 let axis_world_0 = links[1].rotation * Vector3::new(0.0, 0.0, 1.0);
 let axis_world_1 = links[2].rotation * Vector3::new(0.0, 1.0, 0.0);

--- a/src/generated/simple_arm_2dof_flipped.rs
+++ b/src/generated/simple_arm_2dof_flipped.rs
@@ -17,7 +17,7 @@ let link_forearm = link_upper_arm * Translation3::new(0.0, 0.0, 0.9) * { let (s,
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 2]) -> [SMatrix<f64, 6, 2>; 3] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 2]) -> [SMatrix<f64, 6, 2>; 3] {
 let links = compute_fk(joint_cmds);
 let axis_world_0 = links[1].rotation * Vector3::new(0.0, 0.0, 1.0);
 let axis_world_1 = links[0].rotation * Vector3::new(0.0, 1.0, 0.0);

--- a/src/generated/simple_arm_3dof_rrp.rs
+++ b/src/generated/simple_arm_3dof_rrp.rs
@@ -18,7 +18,7 @@ let link_ee_link = link_link2 * Translation3::new(0.25, 0.0, 0.0) * Translation3
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 3]) -> [SMatrix<f64, 6, 3>; 4] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 3]) -> [SMatrix<f64, 6, 3>; 4] {
 let links = compute_fk(joint_cmds);
 let axis_world_0 = links[1].rotation * Vector3::new(0.0, 0.0, 1.0);
 let axis_world_1 = links[2].rotation * Vector3::new(0.0, 1.0, 0.0);

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -68,7 +68,7 @@ let link_laser = link_base_link;
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 13]) -> [SMatrix<f64, 6, 13>; 54] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 13]) -> [SMatrix<f64, 6, 13>; 54] {
 let links = compute_fk(joint_cmds);
 let axis_world_23 = links[24].rotation * Vector3::new(0.0, 0.0, 1.0);
 let axis_world_25 = links[26].rotation * Vector3::new(1.0, 0.0, 0.0);

--- a/src/generated/wuji_hand_v1_right.rs
+++ b/src/generated/wuji_hand_v1_right.rs
@@ -40,7 +40,7 @@ let link_right_finger5_tip_link = link_right_finger5_link4 * Translation3::new(-
 use nalgebra::{SMatrix, Vector6};
 #[allow(non_snake_case)]
 #[rustfmt::skip]
-pub fn compute_jacobian(joint_cmds: &[f64; 20]) -> [SMatrix<f64, 6, 20>; 26] {
+pub fn compute_link_jacobians(joint_cmds: &[f64; 20]) -> [SMatrix<f64, 6, 20>; 26] {
 let links = compute_fk(joint_cmds);
 let axis_world_0 = links[1].rotation * Vector3::new(0.0, 1.0, 0.0);
 let axis_world_1 = links[2].rotation * Vector3::new(0.0, 1.0, 0.0);

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -138,16 +138,11 @@ impl GalawModel {
 
         let mut jacobian = Matrix6xX::zeros(self.num_actuated_joints);
 
-        let mut child_to_joint: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
-        for (joint_idx, joint) in self.joints.iter().enumerate() {
-            child_to_joint.insert(joint.child_link_idx, joint_idx);
-        }
-
         let links = self.compute_fk(joint_cmds)?;
         let target_position = links[target_link_idx].translation;
 
         let mut current_link_idx = target_link_idx;
-        while let Some(&joint_idx) = child_to_joint.get(&current_link_idx) {
+        while let Some(&joint_idx) = self.link_idx_to_parent_joint_idx.get(&current_link_idx) {
             let joint = &self.joints[joint_idx];
             current_link_idx = joint.parent_link_idx;
 

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -53,8 +53,8 @@ impl GalawModel {
         Ok(links)
     }
 
-    /// Computes Jacobian of a model.
-    pub fn compute_jacobian(&self, joint_cmds: &[f64]) -> Result<Vec<Matrix6xX<f64>>, GalawError> {
+    /// Computes the Jacobian of every link in a model.
+    pub fn compute_link_jacobians(&self, joint_cmds: &[f64]) -> Result<Vec<Matrix6xX<f64>>, GalawError> {
         if joint_cmds.len() != self.num_actuated_joints {
             return Err(KinematicsError::JointCmdLengthMismatch {
                 num_actuated: self.num_actuated_joints,
@@ -156,7 +156,7 @@ impl GalawModel {
                 .into());
             }
 
-            let jac = self.compute_jacobian(&joint_cmds_candidate)?[target_link_idx].clone();
+            let jac = self.compute_link_jacobians(&joint_cmds_candidate)?[target_link_idx].clone();
             let jjt_damped = &jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
             let x = jjt_damped
                 .cholesky()

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,4 +1,6 @@
-use nalgebra::{DVector, Isometry3, Matrix6, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6};
+use nalgebra::{
+    DVector, Isometry3, Matrix6, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6,
+};
 
 use crate::{
     error::{GalawError, KinematicsError},
@@ -54,7 +56,10 @@ impl GalawModel {
     }
 
     /// Computes the Jacobian of every link in a model.
-    pub fn compute_link_jacobians(&self, joint_cmds: &[f64]) -> Result<Vec<Matrix6xX<f64>>, GalawError> {
+    pub fn compute_link_jacobians(
+        &self,
+        joint_cmds: &[f64],
+    ) -> Result<Vec<Matrix6xX<f64>>, GalawError> {
         if joint_cmds.len() != self.num_actuated_joints {
             return Err(KinematicsError::JointCmdLengthMismatch {
                 num_actuated: self.num_actuated_joints,
@@ -118,13 +123,17 @@ impl GalawModel {
     }
 
     /// Computes the Jacobian for a single link of a model.
-    /// 
+    ///
     /// Primarily, this is used for computations where we only need specific links
-    pub fn compute_link_jacobian(&self, joint_cmds: &[f64], target_link_idx: usize) -> Result<Matrix6xX<f64>, GalawError> {
+    pub fn compute_link_jacobian(
+        &self,
+        joint_cmds: &[f64],
+        target_link_idx: usize,
+    ) -> Result<Matrix6xX<f64>, GalawError> {
         if joint_cmds.len() != self.num_actuated_joints {
-            return Err(KinematicsError::JointCmdLengthMismatch { 
-                num_actuated: self.num_actuated_joints, 
-                num_input: joint_cmds.len(), 
+            return Err(KinematicsError::JointCmdLengthMismatch {
+                num_actuated: self.num_actuated_joints,
+                num_input: joint_cmds.len(),
             }
             .into());
         }
@@ -146,11 +155,17 @@ impl GalawModel {
             let joint = &self.joints[joint_idx];
             current_link_idx = joint.parent_link_idx;
 
-            let Some(cmd_idx) = joint.cmd_idx else {continue};
+            let Some(cmd_idx) = joint.cmd_idx else {
+                continue;
+            };
 
             let joint_position = links[joint.child_link_idx].translation;
-            let local_axis = joint.rot_axis.or(joint.lin_axis).expect("actuated joint has an axis");
-            let joint_motion_axis = (links[joint.child_link_idx].rotation * local_axis).into_inner();
+            let local_axis = joint
+                .rot_axis
+                .or(joint.lin_axis)
+                .expect("actuated joint has an axis");
+            let joint_motion_axis =
+                (links[joint.child_link_idx].rotation * local_axis).into_inner();
 
             let (lin_vel, ang_vel) = if joint.rot_axis.is_some() {
                 (
@@ -162,11 +177,10 @@ impl GalawModel {
             };
 
             jacobian.set_column(
-                cmd_idx, 
+                cmd_idx,
                 &Vector6::new(
-                    lin_vel.x, lin_vel.y, lin_vel.z, 
-                    ang_vel.x, ang_vel.y, ang_vel.z,
-                )
+                    lin_vel.x, lin_vel.y, lin_vel.z, ang_vel.x, ang_vel.y, ang_vel.z,
+                ),
             );
         }
 
@@ -192,7 +206,7 @@ impl GalawModel {
         for &joint_idx in chain {
             let joint = &self.joints[joint_idx];
             let cmd = joint.cmd_idx.map(|idx| joint_cmds[idx]).unwrap_or(0.0);
-            
+
             let rotation = match joint.rot_axis {
                 Some(axis) => UnitQuaternion::from_axis_angle(&axis, cmd),
                 None => UnitQuaternion::identity(),
@@ -212,10 +226,15 @@ impl GalawModel {
 
         for (i, &joint_idx) in chain.iter().enumerate() {
             let joint = &self.joints[joint_idx];
-            let Some(cmd_idx) = joint.cmd_idx else { continue };
+            let Some(cmd_idx) = joint.cmd_idx else {
+                continue;
+            };
 
             let joint_position = chain_poses[i].translation;
-            let local_axis = joint.rot_axis.or(joint.lin_axis).expect("actuated joint has an axis");
+            let local_axis = joint
+                .rot_axis
+                .or(joint.lin_axis)
+                .expect("actuated joint has an axis");
             let joint_motion_axis = (chain_poses[i].rotation * local_axis).into_inner();
 
             let (lin_vel, ang_vel) = if joint.rot_axis.is_some() {
@@ -228,10 +247,9 @@ impl GalawModel {
             };
 
             jacobian.set_column(
-                cmd_idx, 
+                cmd_idx,
                 &Vector6::new(
-                    lin_vel.x, lin_vel.y, lin_vel.z, 
-                    ang_vel.x, ang_vel.y, ang_vel.z,
+                    lin_vel.x, lin_vel.y, lin_vel.z, ang_vel.x, ang_vel.y, ang_vel.z,
                 ),
             );
         }
@@ -240,14 +258,14 @@ impl GalawModel {
     }
 
     /// Computes inverse kinematics of a model.
-    pub fn compute_ik(&self, 
-        target_link_idx: usize, 
-        target_pose: &Isometry3<f64>, 
+    pub fn compute_ik(
+        &self,
+        target_link_idx: usize,
+        target_pose: &Isometry3<f64>,
         initial_joint_cmds: &[f64],
     ) -> Result<Vec<f64>, GalawError> {
-
         // IK solver params
-        const ERROR_TOLERANCE: f64 = 1e-5; 
+        const ERROR_TOLERANCE: f64 = 1e-5;
         const DAMPING_FACTOR: f64 = 1e-4;
         const STEP_SIZE: f64 = 1.0;
         const MAX_ITERATIONS: usize = 1000;
@@ -267,27 +285,35 @@ impl GalawModel {
             let rotation_error = target_pose.rotation * current_pose.rotation.inverse();
             let error_rotation = rotation_error.scaled_axis();
             Ok(Vector6::new(
-                error_position.x, error_position.y, error_position.z, 
-                error_rotation.x, error_rotation.y, error_rotation.z,
+                error_position.x,
+                error_position.y,
+                error_position.z,
+                error_rotation.x,
+                error_rotation.y,
+                error_rotation.z,
             ))
         };
-        
-        let mut joint_cmds_candidate = initial_joint_cmds.to_vec(); 
+
+        let mut joint_cmds_candidate = initial_joint_cmds.to_vec();
         let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
         let mut jac: Matrix6xX<f64> = Matrix6xX::zeros(self.num_actuated_joints);
         let mut dq: DVector<f64> = DVector::zeros(self.num_actuated_joints);
 
         let mut current_pose = self.compute_restricted_pose_and_fill_jacobian(
-            &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
+            &chain,
+            &joint_cmds_candidate,
+            &mut chain_poses,
+            &mut jac,
+        );
         let mut error = compute_error(&current_pose)?;
         let mut iterations: usize = 0;
 
         // Applies the Levenberg-Marquardt approach
         while error.norm() > ERROR_TOLERANCE {
             if iterations >= MAX_ITERATIONS {
-                return Err(KinematicsError::IkDidNotConverge { 
-                    iterations, 
-                    final_error: error.norm(), 
+                return Err(KinematicsError::IkDidNotConverge {
+                    iterations,
+                    final_error: error.norm(),
                 }
                 .into());
             }
@@ -303,7 +329,11 @@ impl GalawModel {
             }
 
             current_pose = self.compute_restricted_pose_and_fill_jacobian(
-                &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
+                &chain,
+                &joint_cmds_candidate,
+                &mut chain_poses,
+                &mut jac,
+            );
             error = compute_error(&current_pose)?;
             iterations += 1;
         }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -173,12 +173,13 @@ impl GalawModel {
         Ok(jacobian)
     }
 
-    /// Computes the pose and Jacobian of one link along a precomputed chain.
+    /// Computes the pose of one link along a precomputed chain, and fills
+    /// `jacobian` with that link's Jacobian in place.
     ///
     /// Primarily, this is used by `compute_ik`'s loop, which needs both values
     /// every iteration without recomputing the chain or walking the whole model.
     #[inline]
-    fn compute_restricted_pose_and_jacobian(
+    fn compute_restricted_pose_and_fill_jacobian(
         &self,
         chain: &[usize],
         joint_cmds: &[f64],
@@ -276,7 +277,7 @@ impl GalawModel {
         let mut jac: Matrix6xX<f64> = Matrix6xX::zeros(self.num_actuated_joints);
         let mut dq: DVector<f64> = DVector::zeros(self.num_actuated_joints);
 
-        let mut current_pose = self.compute_restricted_pose_and_jacobian(
+        let mut current_pose = self.compute_restricted_pose_and_fill_jacobian(
             &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
         let mut error = compute_error(&current_pose)?;
         let mut iterations: usize = 0;
@@ -301,7 +302,7 @@ impl GalawModel {
                 *q += STEP_SIZE * dq_i;
             }
 
-            current_pose = self.compute_restricted_pose_and_jacobian(
+            current_pose = self.compute_restricted_pose_and_fill_jacobian(
                 &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
             error = compute_error(&current_pose)?;
             iterations += 1;

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -217,7 +217,7 @@ impl GalawModel {
             };
 
             let joint_local = joint.transform * Isometry3::from_parts(translation, rotation);
-            pose = pose * joint_local;
+            pose *= joint_local;
             chain_poses.push(pose);
         }
 

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -117,6 +117,67 @@ impl GalawModel {
         Ok(jacobians)
     }
 
+    /// Computes the Jacobian for a single link of a model.
+    /// 
+    /// Primarily, this is used for computations where we only need specific links
+    pub fn compute_link_jacobian(&self, joint_cmds: &[f64], target_link_idx: usize) -> Result<Matrix6xX<f64>, GalawError> {
+        if joint_cmds.len() != self.num_actuated_joints {
+            return Err(KinematicsError::JointCmdLengthMismatch { 
+                num_actuated: self.num_actuated_joints, 
+                num_input: joint_cmds.len(), 
+            }
+            .into());
+        }
+        if target_link_idx >= self.links.len() {
+            return Err(KinematicsError::LinkIdxOutOfBounds {
+                num_links: self.links.len(),
+                requested: target_link_idx,
+            }
+            .into());
+        }
+
+        let mut jacobian = Matrix6xX::zeros(self.num_actuated_joints);
+
+        let mut child_to_joint: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+        for (joint_idx, joint) in self.joints.iter().enumerate() {
+            child_to_joint.insert(joint.child_link_idx, joint_idx);
+        }
+
+        let links = self.compute_fk(joint_cmds)?;
+        let target_position = links[target_link_idx].translation;
+
+        let mut current_link_idx = target_link_idx;
+        while let Some(&joint_idx) = child_to_joint.get(&current_link_idx) {
+            let joint = &self.joints[joint_idx];
+            current_link_idx = joint.parent_link_idx;
+
+            let Some(cmd_idx) = joint.cmd_idx else {continue};
+
+            let joint_position = links[joint.child_link_idx].translation;
+            let local_axis = joint.rot_axis.or(joint.lin_axis).expect("actuated joint has an axis");
+            let joint_motion_axis = (links[joint.child_link_idx].rotation * local_axis).into_inner();
+
+            let (lin_vel, ang_vel) = if joint.rot_axis.is_some() {
+                (
+                    joint_motion_axis.cross(&(target_position.vector - joint_position.vector)),
+                    joint_motion_axis,
+                )
+            } else {
+                (joint_motion_axis, Vector3::zeros())
+            };
+
+            jacobian.set_column(
+                cmd_idx, 
+                &Vector6::new(
+                    lin_vel.x, lin_vel.y, lin_vel.z, 
+                    ang_vel.x, ang_vel.y, ang_vel.z,
+                )
+            );
+        }
+
+        Ok(jacobian)
+    }
+
     /// Computes inverse kinematics of a model.
     pub fn compute_ik(&self, 
         target_link_idx: usize, 
@@ -156,7 +217,7 @@ impl GalawModel {
                 .into());
             }
 
-            let jac = self.compute_link_jacobians(&joint_cmds_candidate)?[target_link_idx].clone();
+            let jac = self.compute_link_jacobian(&joint_cmds_candidate, target_link_idx)?;
             let jjt_damped = &jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
             let x = jjt_damped
                 .cholesky()

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Isometry3, Matrix6, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6};
+use nalgebra::{DVector, Isometry3, Matrix6, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6};
 
 use crate::{
     error::{GalawError, KinematicsError},
@@ -274,6 +274,7 @@ impl GalawModel {
         let mut joint_cmds_candidate = initial_joint_cmds.to_vec(); 
         let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
         let mut jac: Matrix6xX<f64> = Matrix6xX::zeros(self.num_actuated_joints);
+        let mut dq: DVector<f64> = DVector::zeros(self.num_actuated_joints);
 
         let mut current_pose = self.compute_restricted_pose_and_jacobian(
             &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
@@ -295,7 +296,7 @@ impl GalawModel {
                 .cholesky()
                 .expect("J*J^T + damping*I is always positive definite for damping > 0")
                 .solve(&error);
-            let dq = jac.transpose() * x;
+            jac.tr_mul_to(&x, &mut dq);
             for (q, dq_i) in joint_cmds_candidate.iter_mut().zip(dq.iter()) {
                 *q += STEP_SIZE * dq_i;
             }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Isometry3, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6};
+use nalgebra::{Isometry3, Matrix6, Matrix6xX, Translation3, UnitQuaternion, Vector3, Vector6};
 
 use crate::{
     error::{GalawError, KinematicsError},
@@ -115,5 +115,62 @@ impl GalawModel {
         }
 
         Ok(jacobians)
+    }
+
+    /// Computes inverse kinematics of a model.
+    pub fn compute_ik(&self, 
+        target_link_idx: usize, 
+        target_pose: &Isometry3<f64>, 
+        initial_joint_cmds: &[f64],
+    ) -> Result<Vec<f64>, GalawError> {
+
+        // IK solver params
+        const ERROR_TOLERANCE: f64 = 1e-5; 
+        const DAMPING_FACTOR: f64 = 1e-4;
+        const STEP_SIZE: f64 = 1.0;
+        const MAX_ITERATIONS: usize = 1000;
+
+        // Helper to compute error
+        let compute_error = |joint_cmds: &[f64]| -> Result<Vector6<f64>, GalawError> {
+            let current_pose = self.compute_fk(joint_cmds)?[target_link_idx];
+            let error_position = target_pose.translation.vector - current_pose.translation.vector;
+            let rotation_error = target_pose.rotation * current_pose.rotation.inverse();
+            let error_rotation = rotation_error.scaled_axis();
+            Ok(Vector6::new(
+                error_position.x, error_position.y, error_position.z, 
+                error_rotation.x, error_rotation.y, error_rotation.z,
+            ))
+        };
+        
+        let mut joint_cmds_candidate = initial_joint_cmds.to_vec(); 
+        let mut error = compute_error(&joint_cmds_candidate)?;
+        let mut iterations: usize = 0;
+
+        // Applies the Levenberg-Marquardt approach
+        while error.norm() > ERROR_TOLERANCE {
+            if iterations >= MAX_ITERATIONS {
+                return Err(KinematicsError::IkDidNotConverge { 
+                    iterations, 
+                    final_error: error.norm(), 
+                }
+                .into());
+            }
+
+            let jac = self.compute_jacobian(&joint_cmds_candidate)?[target_link_idx].clone();
+            let jjt_damped = &jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+            let x = jjt_damped
+                .cholesky()
+                .expect("J*J^T + damping*I is always positive definite for damping > 0")
+                .solve(&error);
+            let dq = jac.transpose() * x;
+            for (q, dq_i) in joint_cmds_candidate.iter_mut().zip(dq.iter()) {
+                *q += STEP_SIZE * dq_i;
+            }
+
+            error = compute_error(&joint_cmds_candidate)?;
+            iterations += 1;
+        }
+
+        Ok(joint_cmds_candidate)
     }
 }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -182,9 +182,11 @@ impl GalawModel {
         &self,
         chain: &[usize],
         joint_cmds: &[f64],
-    ) -> (Isometry3<f64>, Matrix6xX<f64>) {
+        chain_poses: &mut Vec<Isometry3<f64>>,
+        jacobian: &mut Matrix6xX<f64>,
+    ) -> Isometry3<f64> {
+        chain_poses.clear();
         let mut pose = Isometry3::identity();
-        let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
 
         for &joint_idx in chain {
             let joint = &self.joints[joint_idx];
@@ -205,7 +207,7 @@ impl GalawModel {
         }
 
         let target_position = pose.translation;
-        let mut jacobian = Matrix6xX::zeros(self.num_actuated_joints);
+        jacobian.fill(0.0);
 
         for (i, &joint_idx) in chain.iter().enumerate() {
             let joint = &self.joints[joint_idx];
@@ -233,7 +235,7 @@ impl GalawModel {
             );
         }
 
-        (pose, jacobian)
+        pose
     }
 
     /// Computes inverse kinematics of a model.
@@ -270,7 +272,11 @@ impl GalawModel {
         };
         
         let mut joint_cmds_candidate = initial_joint_cmds.to_vec(); 
-        let (mut current_pose, mut jac) = self.compute_restricted_pose_and_jacobian(&chain, &joint_cmds_candidate);
+        let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
+        let mut jac: Matrix6xX<f64> = Matrix6xX::zeros(self.num_actuated_joints);
+
+        let mut current_pose = self.compute_restricted_pose_and_jacobian(
+            &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
         let mut error = compute_error(&current_pose)?;
         let mut iterations: usize = 0;
 
@@ -294,9 +300,8 @@ impl GalawModel {
                 *q += STEP_SIZE * dq_i;
             }
 
-            let (new_pose, new_jac) = self.compute_restricted_pose_and_jacobian(&chain, &joint_cmds_candidate);
-            current_pose = new_pose;
-            jac = new_jac;
+            current_pose = self.compute_restricted_pose_and_jacobian(
+                &chain, &joint_cmds_candidate, &mut chain_poses, &mut jac);
             error = compute_error(&current_pose)?;
             iterations += 1;
         }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -173,6 +173,69 @@ impl GalawModel {
         Ok(jacobian)
     }
 
+    /// Computes the pose and Jacobian of one link along a precomputed chain.
+    ///
+    /// Primarily, this is used by `compute_ik`'s loop, which needs both values
+    /// every iteration without recomputing the chain or walking the whole model.
+    #[inline]
+    fn compute_restricted_pose_and_jacobian(
+        &self,
+        chain: &[usize],
+        joint_cmds: &[f64],
+    ) -> (Isometry3<f64>, Matrix6xX<f64>) {
+        let mut pose = Isometry3::identity();
+        let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
+
+        for &joint_idx in chain {
+            let joint = &self.joints[joint_idx];
+            let cmd = joint.cmd_idx.map(|idx| joint_cmds[idx]).unwrap_or(0.0);
+            
+            let rotation = match joint.rot_axis {
+                Some(axis) => UnitQuaternion::from_axis_angle(&axis, cmd),
+                None => UnitQuaternion::identity(),
+            };
+            let translation = match joint.lin_axis {
+                Some(axis) => Translation3::from(axis.into_inner() * cmd),
+                None => Translation3::identity(),
+            };
+
+            let joint_local = joint.transform * Isometry3::from_parts(translation, rotation);
+            pose = pose * joint_local;
+            chain_poses.push(pose);
+        }
+
+        let target_position = pose.translation;
+        let mut jacobian = Matrix6xX::zeros(self.num_actuated_joints);
+
+        for (i, &joint_idx) in chain.iter().enumerate() {
+            let joint = &self.joints[joint_idx];
+            let Some(cmd_idx) = joint.cmd_idx else { continue };
+
+            let joint_position = chain_poses[i].translation;
+            let local_axis = joint.rot_axis.or(joint.lin_axis).expect("actuated joint has an axis");
+            let joint_motion_axis = (chain_poses[i].rotation * local_axis).into_inner();
+
+            let (lin_vel, ang_vel) = if joint.rot_axis.is_some() {
+                (
+                    joint_motion_axis.cross(&(target_position.vector - joint_position.vector)),
+                    joint_motion_axis,
+                )
+            } else {
+                (joint_motion_axis, Vector3::zeros())
+            };
+
+            jacobian.set_column(
+                cmd_idx, 
+                &Vector6::new(
+                    lin_vel.x, lin_vel.y, lin_vel.z, 
+                    ang_vel.x, ang_vel.y, ang_vel.z,
+                ),
+            );
+        }
+
+        (pose, jacobian)
+    }
+
     /// Computes inverse kinematics of a model.
     pub fn compute_ik(&self, 
         target_link_idx: usize, 
@@ -186,9 +249,17 @@ impl GalawModel {
         const STEP_SIZE: f64 = 1.0;
         const MAX_ITERATIONS: usize = 1000;
 
-        // Helper to compute error
-        let compute_error = |joint_cmds: &[f64]| -> Result<Vector6<f64>, GalawError> {
-            let current_pose = self.compute_fk(joint_cmds)?[target_link_idx];
+        // Constructing kinematic chain from root to target
+        let mut chain: Vec<usize> = Vec::new();
+        let mut walk_link_idx = target_link_idx;
+        while let Some(&joint_idx) = self.link_idx_to_parent_joint_idx.get(&walk_link_idx) {
+            chain.push(joint_idx);
+            walk_link_idx = self.joints[joint_idx].parent_link_idx;
+        }
+        chain.reverse();
+
+        // Helper to compute pose error
+        let compute_error = |current_pose: &Isometry3<f64>| -> Result<Vector6<f64>, GalawError> {
             let error_position = target_pose.translation.vector - current_pose.translation.vector;
             let rotation_error = target_pose.rotation * current_pose.rotation.inverse();
             let error_rotation = rotation_error.scaled_axis();
@@ -199,7 +270,8 @@ impl GalawModel {
         };
         
         let mut joint_cmds_candidate = initial_joint_cmds.to_vec(); 
-        let mut error = compute_error(&joint_cmds_candidate)?;
+        let (mut current_pose, mut jac) = self.compute_restricted_pose_and_jacobian(&chain, &joint_cmds_candidate);
+        let mut error = compute_error(&current_pose)?;
         let mut iterations: usize = 0;
 
         // Applies the Levenberg-Marquardt approach
@@ -212,7 +284,6 @@ impl GalawModel {
                 .into());
             }
 
-            let jac = self.compute_link_jacobian(&joint_cmds_candidate, target_link_idx)?;
             let jjt_damped = &jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
             let x = jjt_damped
                 .cholesky()
@@ -223,7 +294,10 @@ impl GalawModel {
                 *q += STEP_SIZE * dq_i;
             }
 
-            error = compute_error(&joint_cmds_candidate)?;
+            let (new_pose, new_jac) = self.compute_restricted_pose_and_jacobian(&chain, &joint_cmds_candidate);
+            current_pose = new_pose;
+            jac = new_jac;
+            error = compute_error(&current_pose)?;
             iterations += 1;
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -224,7 +224,12 @@ fn dfs_visit(
 }
 
 /// Resolved joints (in DFS order), link name -> index, and joint name -> cmd_idx.
-type ResolvedJoints = (Vec<Joint>, HashMap<String, usize>, HashMap<String, usize>);
+type ResolvedJoints = (
+    Vec<Joint>, 
+    HashMap<String, usize>, // link_name -> cmd_idx
+    HashMap<String, usize>, // joint_name -> cmd_idx
+    HashMap<usize, usize>,  // link_name -> parent joint_idx
+);
 
 /// Resolves joint order for downstream functions.
 ///
@@ -313,7 +318,13 @@ fn resolve_joint_order(
         .filter_map(|j| j.cmd_idx.map(|idx| (j.name.clone(), idx)))
         .collect();
 
-    Ok((ordered_joints, link_name_to_idx, joint_name_to_idx))
+    let link_idx_to_parent_joint_idx: HashMap<usize, usize> = ordered_joints
+        .iter()
+        .enumerate()
+        .map(|(joint_idx, j)| (j.child_link_idx, joint_idx))
+        .collect();
+
+    Ok((ordered_joints, link_name_to_idx, joint_name_to_idx, link_idx_to_parent_joint_idx))
 }
 
 /// Parses a URDF file into a [`GalawModel`].
@@ -358,7 +369,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, GalawError> {
         }
     }
 
-    let (ordered_joints, link_name_to_idx, joint_name_to_idx) =
+    let (ordered_joints, link_name_to_idx, joint_name_to_idx, link_idx_to_parent_joint_idx) =
         resolve_joint_order(&links, &joints)?;
 
     let num_actuated_joints = ordered_joints
@@ -372,6 +383,7 @@ pub fn load_urdf(urdf_path: &str) -> Result<GalawModel, GalawError> {
         link_name_to_idx,
         joints: ordered_joints,
         joint_name_to_idx,
+        link_idx_to_parent_joint_idx,
         num_actuated_joints,
     })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -225,7 +225,7 @@ fn dfs_visit(
 
 /// Resolved joints (in DFS order), link name -> index, and joint name -> cmd_idx.
 type ResolvedJoints = (
-    Vec<Joint>, 
+    Vec<Joint>,
     HashMap<String, usize>, // link_name -> cmd_idx
     HashMap<String, usize>, // joint_name -> cmd_idx
     HashMap<usize, usize>,  // link_name -> parent joint_idx
@@ -324,7 +324,12 @@ fn resolve_joint_order(
         .map(|(joint_idx, j)| (j.child_link_idx, joint_idx))
         .collect();
 
-    Ok((ordered_joints, link_name_to_idx, joint_name_to_idx, link_idx_to_parent_joint_idx))
+    Ok((
+        ordered_joints,
+        link_name_to_idx,
+        joint_name_to_idx,
+        link_idx_to_parent_joint_idx,
+    ))
 }
 
 /// Parses a URDF file into a [`GalawModel`].

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,6 +78,8 @@ pub struct GalawModel {
     pub link_name_to_idx: HashMap<String, usize>,
     /// Maps an actuated joint's name to its `cmd_idx` (its position in a `joint_cmds` slice).
     pub joint_name_to_idx: HashMap<String, usize>,
+    /// Maps a link's index to index of joint that connectes it to parent (edge in tree)
+    pub link_idx_to_parent_joint_idx: HashMap<usize, usize>,
     /// Number of actuated (non-`Fixed`) joints — the expected length of a `joint_cmds` slice.
     pub num_actuated_joints: usize,
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
 // Third-party
+use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 use rand::RngExt;
 use rand_chacha::ChaCha8Rng;
 
@@ -19,6 +20,31 @@ pub fn assert_close(a: f64, b: f64) {
         (a - b).abs() < TEST_TOLERANCE,
         "expected {b}, got {a} OR not within {TEST_TOLERANCE}"
     );
+}
+
+/// Need to do this test because quaternions double-cover rotations (q=-q are same rotation)
+fn assert_orientation_close(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>) {
+    let dot_prod = a.i * b.i + a.j * b.j + a.k * b.k + a.w * b.w;
+    assert_close(dot_prod.abs(), 1.0);
+}
+
+fn assert_position3d_close(a: &Translation3<f64>, b: &Translation3<f64>) {
+    assert_close(a.x, b.x);
+    assert_close(a.y, b.y);
+    assert_close(a.z, b.z);
+}
+
+pub fn assert_galaw_k_transform_close(galaw_transform: &Isometry3<f64>, k_iso: &k::nalgebra::Isometry3<f64>) {
+    assert_position3d_close(&galaw_transform.translation, &k_iso.translation);
+    assert_orientation_close(&galaw_transform.rotation, &k_iso.rotation);
+}
+
+/// Both sides are plain `nalgebra::Isometry3<f64>` here (dynamic vs codegen'd
+/// FK), unlike `assert_galaw_k_transform_close` which bridges to `k`'s own re-exported
+/// nalgebra type.
+pub fn assert_galaw_transform_close(a: &Isometry3<f64>, b: &Isometry3<f64>) {
+    assert_position3d_close(&a.translation, &b.translation);
+    assert_orientation_close(&a.rotation, &b.rotation);
 }
 
 /// Sets up the different kinematics model for testing.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,7 +25,11 @@ pub fn assert_close(a: f64, b: f64, test_tolerance: &f64) {
 }
 
 /// Need to do this test because quaternions double-cover rotations (q=-q are same rotation)
-fn assert_orientation_close(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>, test_tolerance: &f64) {
+fn assert_orientation_close(
+    a: &UnitQuaternion<f64>,
+    b: &UnitQuaternion<f64>,
+    test_tolerance: &f64,
+) {
     let dot_prod = a.i * b.i + a.j * b.j + a.k * b.k + a.w * b.w;
     assert_close(dot_prod.abs(), 1.0, test_tolerance);
 }
@@ -37,11 +41,15 @@ fn assert_position3d_close(a: &Translation3<f64>, b: &Translation3<f64>, test_to
 }
 
 pub fn assert_galaw_k_transform_close(
-    galaw_transform: &Isometry3<f64>, 
+    galaw_transform: &Isometry3<f64>,
     k_iso: &k::nalgebra::Isometry3<f64>,
     test_tolerance: &f64,
 ) {
-    assert_position3d_close(&galaw_transform.translation, &k_iso.translation, test_tolerance);
+    assert_position3d_close(
+        &galaw_transform.translation,
+        &k_iso.translation,
+        test_tolerance,
+    );
     assert_orientation_close(&galaw_transform.rotation, &k_iso.rotation, test_tolerance);
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,7 @@
+// Each tests/*.rs compiles as its own crate, so dead_code is checked
+// per-binary — a function unused here may still be used by a sibling test.
+#![allow(dead_code)]
+
 // Third-party
 use nalgebra::{Isometry3, Translation3, UnitQuaternion};
 use rand::RngExt;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,41 +10,43 @@ use galaw::{load_urdf, types::GalawModel};
 pub type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 // ---- CONSTANTS ----
-pub const TEST_TOLERANCE: f64 = 1e-10;
 pub const RNG_SEED: u64 = 42;
-pub const NUM_POSES: usize = 128;
 
 // ---- HELPERS ----
-pub fn assert_close(a: f64, b: f64) {
+pub fn assert_close(a: f64, b: f64, test_tolerance: &f64) {
     assert!(
-        (a - b).abs() < TEST_TOLERANCE,
-        "expected {b}, got {a} OR not within {TEST_TOLERANCE}"
+        (a - b).abs() < *test_tolerance,
+        "expected {b}, got {a} OR not within {test_tolerance}"
     );
 }
 
 /// Need to do this test because quaternions double-cover rotations (q=-q are same rotation)
-fn assert_orientation_close(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>) {
+fn assert_orientation_close(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>, test_tolerance: &f64) {
     let dot_prod = a.i * b.i + a.j * b.j + a.k * b.k + a.w * b.w;
-    assert_close(dot_prod.abs(), 1.0);
+    assert_close(dot_prod.abs(), 1.0, test_tolerance);
 }
 
-fn assert_position3d_close(a: &Translation3<f64>, b: &Translation3<f64>) {
-    assert_close(a.x, b.x);
-    assert_close(a.y, b.y);
-    assert_close(a.z, b.z);
+fn assert_position3d_close(a: &Translation3<f64>, b: &Translation3<f64>, test_tolerance: &f64) {
+    assert_close(a.x, b.x, test_tolerance);
+    assert_close(a.y, b.y, test_tolerance);
+    assert_close(a.z, b.z, test_tolerance);
 }
 
-pub fn assert_galaw_k_transform_close(galaw_transform: &Isometry3<f64>, k_iso: &k::nalgebra::Isometry3<f64>) {
-    assert_position3d_close(&galaw_transform.translation, &k_iso.translation);
-    assert_orientation_close(&galaw_transform.rotation, &k_iso.rotation);
+pub fn assert_galaw_k_transform_close(
+    galaw_transform: &Isometry3<f64>, 
+    k_iso: &k::nalgebra::Isometry3<f64>,
+    test_tolerance: &f64,
+) {
+    assert_position3d_close(&galaw_transform.translation, &k_iso.translation, test_tolerance);
+    assert_orientation_close(&galaw_transform.rotation, &k_iso.rotation, test_tolerance);
 }
 
 /// Both sides are plain `nalgebra::Isometry3<f64>` here (dynamic vs codegen'd
 /// FK), unlike `assert_galaw_k_transform_close` which bridges to `k`'s own re-exported
 /// nalgebra type.
-pub fn assert_galaw_transform_close(a: &Isometry3<f64>, b: &Isometry3<f64>) {
-    assert_position3d_close(&a.translation, &b.translation);
-    assert_orientation_close(&a.rotation, &b.rotation);
+pub fn assert_galaw_transform_close(a: &Isometry3<f64>, b: &Isometry3<f64>, test_tolerance: &f64) {
+    assert_position3d_close(&a.translation, &b.translation, test_tolerance);
+    assert_orientation_close(&a.rotation, &b.rotation, test_tolerance);
 }
 
 /// Sets up the different kinematics model for testing.

--- a/tests/fk_correctness.rs
+++ b/tests/fk_correctness.rs
@@ -1,7 +1,7 @@
 /// Tests the correctness of the implemented forward kinematics function
 /// with Rust's k library
 // Third-party
-use nalgebra::{Isometry3, Translation3, UnitQuaternion};
+use nalgebra::{Isometry3};
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -10,34 +10,9 @@ use galaw::{load_urdf, types::GalawModel};
 
 mod common;
 use common::{
-    NUM_POSES, RNG_SEED, TestResult, assert_close, random_joint_cmds, setup_kinematic_models,
-    zero_joint_cmds,
+    NUM_POSES, RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
+    zero_joint_cmds, assert_galaw_k_transform_close, assert_galaw_transform_close,
 };
-
-/// Need to do this test because quaternions double-cover rotations (q=-q are same rotation)
-fn assert_orientation_close(a: &UnitQuaternion<f64>, b: &UnitQuaternion<f64>) {
-    let dot_prod = a.i * b.i + a.j * b.j + a.k * b.k + a.w * b.w;
-    assert_close(dot_prod.abs(), 1.0);
-}
-
-fn assert_position3d_close(a: &Translation3<f64>, b: &Translation3<f64>) {
-    assert_close(a.x, b.x);
-    assert_close(a.y, b.y);
-    assert_close(a.z, b.z);
-}
-
-fn assert_transform_close(galaw_transform: &Isometry3<f64>, k_iso: &k::nalgebra::Isometry3<f64>) {
-    assert_position3d_close(&galaw_transform.translation, &k_iso.translation);
-    assert_orientation_close(&galaw_transform.rotation, &k_iso.rotation);
-}
-
-/// Both sides are plain `nalgebra::Isometry3<f64>` here (dynamic vs codegen'd
-/// FK), unlike `assert_transform_close` which bridges to `k`'s own re-exported
-/// nalgebra type.
-fn assert_galaw_transform_close(a: &Isometry3<f64>, b: &Isometry3<f64>) {
-    assert_position3d_close(&a.translation, &b.translation);
-    assert_orientation_close(&a.rotation, &b.rotation);
-}
 
 fn assert_galaw_fk_matches_k(
     galaw_model: &GalawModel,
@@ -57,7 +32,7 @@ fn assert_galaw_fk_matches_k(
             .world_transform()
             .ok_or("invalid result")?;
 
-        assert_transform_close(&galaw_result[i], &k_link);
+        assert_galaw_k_transform_close(&galaw_result[i], &k_link);
     }
 
     Ok(())

--- a/tests/fk_correctness.rs
+++ b/tests/fk_correctness.rs
@@ -1,7 +1,7 @@
 /// Tests the correctness of the implemented forward kinematics function
 /// with Rust's k library
 // Third-party
-use nalgebra::{Isometry3};
+use nalgebra::Isometry3;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
@@ -10,8 +10,8 @@ use galaw::{load_urdf, types::GalawModel};
 
 mod common;
 use common::{
-    RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
-    zero_joint_cmds, assert_galaw_k_transform_close, assert_galaw_transform_close,
+    RNG_SEED, TestResult, assert_galaw_k_transform_close, assert_galaw_transform_close,
+    random_joint_cmds, setup_kinematic_models, zero_joint_cmds,
 };
 
 // ---- CONSTANTS ----

--- a/tests/fk_correctness.rs
+++ b/tests/fk_correctness.rs
@@ -10,9 +10,13 @@ use galaw::{load_urdf, types::GalawModel};
 
 mod common;
 use common::{
-    NUM_POSES, RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
+    RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
     zero_joint_cmds, assert_galaw_k_transform_close, assert_galaw_transform_close,
 };
+
+// ---- CONSTANTS ----
+const NUM_POSES: usize = 128;
+const TEST_TOLERANCE: f64 = 1e-7;
 
 fn assert_galaw_fk_matches_k(
     galaw_model: &GalawModel,
@@ -32,7 +36,7 @@ fn assert_galaw_fk_matches_k(
             .world_transform()
             .ok_or("invalid result")?;
 
-        assert_galaw_k_transform_close(&galaw_result[i], &k_link);
+        assert_galaw_k_transform_close(&galaw_result[i], &k_link, &TEST_TOLERANCE);
     }
 
     Ok(())
@@ -92,7 +96,7 @@ fn check_generated_matches_dynamic<const N: usize, const M: usize>(
         let generated_links = generated_compute_fk(&joint_cmds_arr);
 
         for i in 0..galaw_model.links.len() {
-            assert_galaw_transform_close(&dynamic_links[i], &generated_links[i]);
+            assert_galaw_transform_close(&dynamic_links[i], &generated_links[i], &TEST_TOLERANCE);
         }
     }
 

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -16,8 +16,9 @@ use common::{
 use crate::common::assert_galaw_transform_close;
 
 // ---- CONSTANTS ----
-pub const TEST_TOLERANCE: f64 = 1e-4;
-pub const NUM_POSES: usize = 128;
+const TEST_TOLERANCE: f64 = 1e-4;
+const NUM_POSES: usize = 128;
+const MAX_PERTUBATION: f64 = 0.5;   // radians/meters offset from target for IK initial pose
 
 /// Returns links that are valid IK targets (leaves of the kinematic tree)
 fn candidate_target_links(galaw_model: &GalawModel) -> Vec<usize> {
@@ -39,6 +40,31 @@ fn candidate_target_links(galaw_model: &GalawModel) -> Vec<usize> {
     (0..galaw_model.links.len())
         .filter(|&link_idx| {
             !parent_indices.contains(&link_idx) && !ancestors_by_link[link_idx].is_empty()
+        })
+        .collect()
+}
+
+/// Perturbs base joint config by small random offset per joint.
+/// 
+/// This is done to better replicate how IK is used in practice
+fn perturbed_joint_cmds(
+    model: &GalawModel,
+    base: &[f64],
+    rng: &mut ChaCha8Rng,
+    max_offset: f64,
+) -> Vec<f64> {
+    model
+        .joints
+        .iter()
+        .filter(|j| j.cmd_idx.is_some())
+        .zip(base.iter())
+        .map(|(j, &base_value)| {
+            let offset = rng.random_range(-max_offset..max_offset);
+            let perturbed = base_value + offset;
+            match (j.limit_lower, j.limit_upper) {
+                (Some(lower), Some(upper)) => perturbed.clamp(lower, upper),
+                _ => perturbed,
+            }
         })
         .collect()
 }
@@ -90,7 +116,7 @@ fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
     for _ in 0..NUM_POSES {
         let target_link_idx = candidates[rng.random_range(0..candidates.len())];
         let target_joint_cmd = random_joint_cmds(&galaw_model, &mut rng);
-        let init_joint_cmd = random_joint_cmds(&galaw_model, &mut rng);
+        let init_joint_cmd = perturbed_joint_cmds(&galaw_model, &target_joint_cmd, &mut rng, MAX_PERTUBATION);
         assert_galaw_ik_correctness(&galaw_model, target_link_idx, &target_joint_cmd, &init_joint_cmd)?;
     }
 

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -1,7 +1,7 @@
 /// Tests the correctness of the implemented inverse kinematics function
 /// with Rust's k library
 // Third-party
-use rand::{SeedableRng};
+use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 // Custom
@@ -16,26 +16,51 @@ use common::{
 use crate::common::assert_galaw_transform_close;
 
 // ---- CONSTANTS ----
-pub const TEST_TOLERANCE: f64 = 1e-10;
+pub const TEST_TOLERANCE: f64 = 1e-4;
 pub const NUM_POSES: usize = 128;
 
+/// Returns links that are valid IK targets (leaves of the kinematic tree)
+fn candidate_target_links(galaw_model: &GalawModel) -> Vec<usize> {
+    let parent_indices: std::collections::HashSet<usize> = galaw_model
+        .joints
+        .iter()
+        .map(|j| j.parent_link_idx)
+        .collect();
+
+    let mut ancestors_by_link: Vec<Vec<usize>> = vec![Vec::new(); galaw_model.links.len()];
+    for (joint_idx, joint) in galaw_model.joints.iter().enumerate() {
+        let mut ancestors = ancestors_by_link[joint.parent_link_idx].clone();
+        if joint.cmd_idx.is_some() {
+            ancestors.push(joint_idx);
+        }
+        ancestors_by_link[joint.child_link_idx] = ancestors;
+    }
+
+    (0..galaw_model.links.len())
+        .filter(|&link_idx| {
+            !parent_indices.contains(&link_idx) && !ancestors_by_link[link_idx].is_empty()
+        })
+        .collect()
+}
+
+/// Assert that IK is correct by running check with internal FK.
 fn assert_galaw_ik_correctness(
     galaw_model: &GalawModel,
+    target_link_idx: usize,
     target_joint_cmd: &[f64],
     init_joint_cmd: &[f64],
 ) -> TestResult {
-    eprintln!("[input] target_joint_cmd = {:?}", target_joint_cmd);
+    eprintln!(
+        "[input] target_link_idx = {target_link_idx}, target_joint_cmd = {:?}", 
+        target_joint_cmd
+    );
     
-    // Known solution
-    let target_link_poses = galaw_model.compute_fk(target_joint_cmd)?;
-    let target_end_effector_pose = target_link_poses[target_link_poses.len() - 1];
-    let target_link_idx = target_link_poses.len() - 1;
+    let target_link_pose = galaw_model.compute_fk(target_joint_cmd)?[target_link_idx];
 
-    let solved_joint_cmds = galaw_model.compute_ik(target_link_idx, &target_end_effector_pose, init_joint_cmd)?;
-    let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?;
-    let solved_end_effector_pose = solved_link_poses[solved_link_poses.len() - 1];
+    let solved_joint_cmds = galaw_model.compute_ik(target_link_idx, &target_link_pose, init_joint_cmd)?;
+    let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
 
-    assert_galaw_transform_close(&target_end_effector_pose, &solved_end_effector_pose);
+    assert_galaw_transform_close(&target_link_pose, &solved_link_poses, &TEST_TOLERANCE);
 
     Ok(())
 }
@@ -45,16 +70,29 @@ fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
     eprintln!("[urdf] {urdf_path}");
     let (galaw_model, _) = setup_kinematic_models(urdf_path);
 
+    let candidates = candidate_target_links(&galaw_model);
+    assert!(
+        !candidates.is_empty(),
+        "no valid IK target links found for {urdf_path}"
+    );
     let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
 
-    // Zero joint cmd
+    // Zero-ish pose
     let zero_joint_cmd: Vec<f64> = zero_joint_cmds(&galaw_model);
     let init_joint_cmd: Vec<f64> = random_joint_cmds(&galaw_model, &mut rng);
     assert_galaw_ik_correctness(
         &galaw_model, 
+        candidates[0],
         &zero_joint_cmd,
         &init_joint_cmd,
-    );
+    )?;
+
+    for _ in 0..NUM_POSES {
+        let target_link_idx = candidates[rng.random_range(0..candidates.len())];
+        let target_joint_cmd = random_joint_cmds(&galaw_model, &mut rng);
+        let init_joint_cmd = random_joint_cmds(&galaw_model, &mut rng);
+        assert_galaw_ik_correctness(&galaw_model, target_link_idx, &target_joint_cmd, &init_joint_cmd)?;
+    }
 
     Ok(())
 }
@@ -73,4 +111,11 @@ macro_rules! ik_correctness_tests {
 
 ik_correctness_tests! {
     simple_arm_2dof  => "assets/urdf/custom/simple_arm_2dof.urdf",
+    simple_arm_3dof_rrp => "assets/urdf/custom/simple-arm_3dof_rrp.urdf",   // Tests revolute and prismatic
+
+    // Third-party robots
+    flexiv_enlight_l => "assets/urdf/third_party/Flexiv_Enlight-L/Enlight-L.urdf",  // Tests revolute and fixed
+    anymal_d => "assets/urdf/third_party/ANYbotics_ANYmal-D/ANYmal-D.urdf",     // Tests revolute and fixed
+    wuji_hand_v1_right => "assets/urdf/third_party/Wuji-Technology_Wuji-Hand/Wuji-Hand-v1_right.urdf",  // Tests revolute and fixed
+    stretch4 => "assets/urdf/third_party/Hello-Robot_Stretch4/Stretch4.urdf",     // Tests continuous, prismatic, revolute, fixed
 }

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -5,20 +5,17 @@ use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 // Custom
-use galaw::{types::GalawModel};
+use galaw::types::GalawModel;
 
 mod common;
-use common::{
-    RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
-    zero_joint_cmds,
-};
+use common::{RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models, zero_joint_cmds};
 
 use crate::common::assert_galaw_transform_close;
 
 // ---- CONSTANTS ----
 const TEST_TOLERANCE: f64 = 1e-4;
 const NUM_POSES: usize = 128;
-const MAX_PERTUBATION: f64 = 0.5;   // radians/meters offset from target for IK initial pose
+const MAX_PERTUBATION: f64 = 0.5; // radians/meters offset from target for IK initial pose
 
 /// Returns links that are valid IK targets (leaves of the kinematic tree)
 fn candidate_target_links(galaw_model: &GalawModel) -> Vec<usize> {
@@ -45,7 +42,7 @@ fn candidate_target_links(galaw_model: &GalawModel) -> Vec<usize> {
 }
 
 /// Perturbs base joint config by small random offset per joint.
-/// 
+///
 /// This is done to better replicate how IK is used in practice
 fn perturbed_joint_cmds(
     model: &GalawModel,
@@ -77,13 +74,14 @@ fn assert_galaw_ik_correctness(
     init_joint_cmd: &[f64],
 ) -> TestResult {
     eprintln!(
-        "[input] target_link_idx = {target_link_idx}, target_joint_cmd = {:?}", 
+        "[input] target_link_idx = {target_link_idx}, target_joint_cmd = {:?}",
         target_joint_cmd
     );
-    
+
     let target_link_pose = galaw_model.compute_fk(target_joint_cmd)?[target_link_idx];
 
-    let solved_joint_cmds = galaw_model.compute_ik(target_link_idx, &target_link_pose, init_joint_cmd)?;
+    let solved_joint_cmds =
+        galaw_model.compute_ik(target_link_idx, &target_link_pose, init_joint_cmd)?;
     let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
 
     assert_galaw_transform_close(&target_link_pose, &solved_link_poses, &TEST_TOLERANCE);
@@ -107,7 +105,7 @@ fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
     let zero_joint_cmd: Vec<f64> = zero_joint_cmds(&galaw_model);
     let init_joint_cmd: Vec<f64> = random_joint_cmds(&galaw_model, &mut rng);
     assert_galaw_ik_correctness(
-        &galaw_model, 
+        &galaw_model,
         candidates[0],
         &zero_joint_cmd,
         &init_joint_cmd,
@@ -116,8 +114,14 @@ fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
     for _ in 0..NUM_POSES {
         let target_link_idx = candidates[rng.random_range(0..candidates.len())];
         let target_joint_cmd = random_joint_cmds(&galaw_model, &mut rng);
-        let init_joint_cmd = perturbed_joint_cmds(&galaw_model, &target_joint_cmd, &mut rng, MAX_PERTUBATION);
-        assert_galaw_ik_correctness(&galaw_model, target_link_idx, &target_joint_cmd, &init_joint_cmd)?;
+        let init_joint_cmd =
+            perturbed_joint_cmds(&galaw_model, &target_joint_cmd, &mut rng, MAX_PERTUBATION);
+        assert_galaw_ik_correctness(
+            &galaw_model,
+            target_link_idx,
+            &target_joint_cmd,
+            &init_joint_cmd,
+        )?;
     }
 
     Ok(())

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -1,0 +1,76 @@
+/// Tests the correctness of the implemented inverse kinematics function
+/// with Rust's k library
+// Third-party
+use rand::{SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+// Custom
+use galaw::{types::GalawModel};
+
+mod common;
+use common::{
+    RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models,
+    zero_joint_cmds,
+};
+
+use crate::common::assert_galaw_transform_close;
+
+// ---- CONSTANTS ----
+pub const TEST_TOLERANCE: f64 = 1e-10;
+pub const NUM_POSES: usize = 128;
+
+fn assert_galaw_ik_correctness(
+    galaw_model: &GalawModel,
+    target_joint_cmd: &[f64],
+    init_joint_cmd: &[f64],
+) -> TestResult {
+    eprintln!("[input] target_joint_cmd = {:?}", target_joint_cmd);
+    
+    // Known solution
+    let target_link_poses = galaw_model.compute_fk(target_joint_cmd)?;
+    let target_end_effector_pose = target_link_poses[target_link_poses.len() - 1];
+    let target_link_idx = target_link_poses.len() - 1;
+
+    let solved_joint_cmds = galaw_model.compute_ik(target_link_idx, &target_end_effector_pose, init_joint_cmd)?;
+    let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?;
+    let solved_end_effector_pose = solved_link_poses[solved_link_poses.len() - 1];
+
+    assert_galaw_transform_close(&target_end_effector_pose, &solved_end_effector_pose);
+
+    Ok(())
+}
+
+/// Run IK check for each URDF.
+fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
+    eprintln!("[urdf] {urdf_path}");
+    let (galaw_model, _) = setup_kinematic_models(urdf_path);
+
+    let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
+
+    // Zero joint cmd
+    let zero_joint_cmd: Vec<f64> = zero_joint_cmds(&galaw_model);
+    let init_joint_cmd: Vec<f64> = random_joint_cmds(&galaw_model, &mut rng);
+    assert_galaw_ik_correctness(
+        &galaw_model, 
+        &zero_joint_cmd,
+        &init_joint_cmd,
+    );
+
+    Ok(())
+}
+
+/// Generates one `#[test]` per URDF.
+macro_rules! ik_correctness_tests {
+    ($($name:ident => $path:expr),* $(,)?) => {
+        $(
+            #[test]
+            fn $name() -> TestResult {
+                check_ik_for_urdf($path)
+            }
+        )*
+    };
+}
+
+ik_correctness_tests! {
+    simple_arm_2dof  => "assets/urdf/custom/simple_arm_2dof.urdf",
+}

--- a/tests/jacobian_correctness.rs
+++ b/tests/jacobian_correctness.rs
@@ -10,8 +10,7 @@ use galaw::types::GalawModel;
 
 mod common;
 use common::{
-    RNG_SEED, TestResult, assert_close, random_joint_cmds, setup_kinematic_models,
-    zero_joint_cmds,
+    RNG_SEED, TestResult, assert_close, random_joint_cmds, setup_kinematic_models, zero_joint_cmds,
 };
 
 // ---- CONSTANTS ----

--- a/tests/jacobian_correctness.rs
+++ b/tests/jacobian_correctness.rs
@@ -10,11 +10,13 @@ use galaw::types::GalawModel;
 
 mod common;
 use common::{
-    NUM_POSES, RNG_SEED, TestResult, assert_close, random_joint_cmds, setup_kinematic_models,
+    RNG_SEED, TestResult, assert_close, random_joint_cmds, setup_kinematic_models,
     zero_joint_cmds,
 };
 
 // ---- CONSTANTS ----
+const NUM_POSES: usize = 128;
+const TEST_TOLERANCE: f64 = 1e-7;
 const FD_EPS: f64 = 1e-6;
 const FD_TOLERANCE: f64 = 1e-5; // looser numerical error for finite difference 
 
@@ -98,6 +100,7 @@ fn asssert_galaw_jacobian_matches_k(
                 assert_close(
                     galaw_link_jacobian[(row, cmd_idx)],
                     k_jacobian[(row, k_col_idx)],
+                    &TEST_TOLERANCE,
                 );
             }
         }
@@ -142,6 +145,7 @@ fn check_generated_jacobian_matches_dynamic<const N: usize, const M: usize>(
                     assert_close(
                         dynamic_jacobians[link_idx][(row, col)],
                         generated_jacobians[link_idx][(row, col)],
+                        &TEST_TOLERANCE,
                     );
                 }
             }

--- a/tests/jacobian_correctness.rs
+++ b/tests/jacobian_correctness.rs
@@ -35,7 +35,7 @@ fn assert_galaw_jacobian_matches_finite_difference(
     galaw_model: &GalawModel,
     joint_cmds: &[f64],
 ) -> TestResult {
-    let jacobians = galaw_model.compute_jacobian(joint_cmds)?;
+    let jacobians = galaw_model.compute_link_jacobians(joint_cmds)?;
 
     for joint in &galaw_model.joints {
         let Some(cmd_idx) = joint.cmd_idx else {
@@ -81,7 +81,7 @@ fn asssert_galaw_jacobian_matches_k(
     k_chain.set_joint_positions(joint_cmds)?;
     k_chain.update_transforms();
 
-    let galaw_jacobian = galaw_model.compute_jacobian(joint_cmds)?;
+    let galaw_jacobian = galaw_model.compute_link_jacobians(joint_cmds)?;
 
     for (target_link_idx, link) in galaw_model.links.iter().enumerate() {
         let galaw_link_jacobian = &galaw_jacobian[target_link_idx];
@@ -124,20 +124,20 @@ fn check_jacobian_matches_fd_for_urdf(urdf_path: &str) -> TestResult {
     Ok(())
 }
 
-/// Runs correctness check generated `compute_jacobian` against the runtime version.
+/// Runs correctness check generated `compute_link_jacobians` against the runtime version.
 fn check_generated_jacobian_matches_dynamic<const N: usize, const M: usize>(
     urdf_path: &str,
-    generated_compute_jacobian: impl Fn(&[f64; N]) -> [SMatrix<f64, 6, N>; M],
+    generated_compute_link_jacobians: impl Fn(&[f64; N]) -> [SMatrix<f64, 6, N>; M],
 ) -> TestResult {
     let galaw_model = galaw::load_urdf(urdf_path)?;
 
     let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
     for _ in 0..NUM_POSES {
         let joint_cmds = random_joint_cmds(&galaw_model, &mut rng);
-        let dynamic_jacobians = galaw_model.compute_jacobian(&joint_cmds)?;
+        let dynamic_jacobians = galaw_model.compute_link_jacobians(&joint_cmds)?;
 
         let joint_cmds_arr: [f64; N] = joint_cmds.clone().try_into().unwrap();
-        let generated_jacobians = generated_compute_jacobian(&joint_cmds_arr);
+        let generated_jacobians = generated_compute_link_jacobians(&joint_cmds_arr);
 
         for link_idx in 0..galaw_model.links.len() {
             for row in 0..6 {
@@ -215,7 +215,7 @@ macro_rules! jacobian_codegen_correctness_test {
             fn matches_dynamic() -> TestResult {
                 check_generated_jacobian_matches_dynamic(
                     $path,
-                    galaw::generated::$module::compute_jacobian,
+                    galaw::generated::$module::compute_link_jacobians,
                 )
             }
         }


### PR DESCRIPTION
# Features
- Created `compute_ik` function. Overal average of 5.3x faster than `k`.
- Created respective testing, benchmarking, and plotting scripts. 
- Created helper functions to optimize IK computation.

# Results
| Robot | Joints [total/actuated] | galaw `compute_ik` | `k::JacobianIkSolver` | Speedup |
|---|---|---|---|---|
| Enlight-L | 9/7 | 6.05 µs (0.165 Mcalls/s) | 157.80 µs (0.006 Mcalls/s) | **26.1x** |
| stretch4 | 53/13 | 5.22 µs (0.192 Mcalls/s) | 46.74 µs (0.021 Mcalls/s) | **9.0x** |
| anymal-D | 95/14 | 5.47 µs (0.183 Mcalls/s) | 14.25 µs (0.070 Mcalls/s) | **2.6x** |
| wujihand-right | 25/20 | 5.52 µs (0.181 Mcalls/s) | 7.35 µs (0.136 Mcalls/s) | **1.3x** |

Geometric mean speedup: **5.3x** faster than `k`.

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/e264836e-ee1b-4206-8709-6f7f6ef0b721" />
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/978058fb-93d4-4578-b1ed-7a7df6d4c865" />
