### PR TITLE
feat: codegen ik

### DIFF
--- a/benches/ik_speed.rs
+++ b/benches/ik_speed.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
 use std::hint::black_box;
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::measurement::WallTime;
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
 use k::InverseKinematicsSolver;
+use nalgebra::Isometry3;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
-use galaw::{fixtures::BENCH_URDFS, load_urdf, types::GalawModel};
+use galaw::{error::KinematicsError, fixtures::BENCH_URDFS, load_urdf, types::GalawModel};
 
 const RNG_SEED: u64 = 42;
 const N_POSES: usize = 100;
@@ -53,6 +55,35 @@ fn target_link(model: &GalawModel) -> usize {
         .unwrap()
 }
 
+/// Benchmarks a codegen'd `compute_ik` under the "galaw-generated" id.
+fn bench_generated_ik<const N: usize>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    galaw_model: &GalawModel,
+    link_idx: usize,
+    bench_id: usize,
+    trials: &[(Vec<f64>, Vec<f64>)],
+    generated_compute_ik: impl Fn(usize, &Isometry3<f64>, &[f64; N]) -> Result<[f64; N], KinematicsError>,
+) {
+    // Conversion to fixed-size arrays happens once, up front - not timed.
+    let trials_arr: Vec<(Vec<f64>, [f64; N])> = trials
+        .iter()
+        .map(|(target, init)| (target.clone(), init.clone().try_into().unwrap()))
+        .collect();
+
+    group.bench_with_input(
+        BenchmarkId::new("galaw-generated", bench_id),
+        &trials_arr,
+        |b, trials| {
+            b.iter(|| {
+                for (target, init) in trials {
+                    let pose = galaw_model.compute_fk(target).unwrap()[link_idx];
+                    let _ = black_box(generated_compute_ik(link_idx, &pose, black_box(init)));
+                }
+            });
+        },
+    );
+}
+
 fn bench_ik(c: &mut Criterion) {
     for &urdf_path in BENCH_URDFS {
         let galaw_model = load_urdf(urdf_path).unwrap();
@@ -72,6 +103,7 @@ fn bench_ik(c: &mut Criterion) {
         let mut group = c.benchmark_group(format!("ik/{}", galaw_model.name));
         group.throughput(criterion::Throughput::Elements(trials.len() as u64));
 
+        // ----- galaw-runtime -----
         group.bench_with_input(
             BenchmarkId::new("galaw-runtime", galaw_model.joints.len()),
             &trials,
@@ -85,6 +117,30 @@ fn bench_ik(c: &mut Criterion) {
             },
         );
 
+        // ----- galaw-generated -----
+        let mut generated_bench_registered = false;
+        macro_rules! bench_ik_if_matches {
+            ($module:ident, $path:expr, $compute_fk:path) => {
+                if urdf_path == $path {
+                    bench_generated_ik(
+                        &mut group,
+                        &galaw_model,
+                        link_idx,
+                        galaw_model.joints.len(),
+                        &trials,
+                        galaw::generated::$module::compute_ik,
+                    );
+                    generated_bench_registered = true;
+                }
+            };
+        }
+        galaw::for_each_generated_robot!(bench_ik_if_matches);
+        assert!(
+            generated_bench_registered,
+            "no generated compute_ik registered for {urdf_path} — run scripts/codegen_all_urdfs.sh"
+        );
+
+        // ----- k -----
         let solver = k::JacobianIkSolver::new(1e-4, 1e-4, 1.0, 1000);
         group.bench_with_input(
             BenchmarkId::new("k", galaw_model.joints.len()),

--- a/benches/ik_speed.rs
+++ b/benches/ik_speed.rs
@@ -62,7 +62,11 @@ fn bench_generated_ik<const N: usize>(
     link_idx: usize,
     bench_id: usize,
     trials: &[(Vec<f64>, Vec<f64>)],
-    generated_compute_ik: impl Fn(usize, &Isometry3<f64>, &[f64; N]) -> Result<[f64; N], KinematicsError>,
+    generated_compute_ik: impl Fn(
+        usize,
+        &Isometry3<f64>,
+        &[f64; N],
+    ) -> Result<[f64; N], KinematicsError>,
 ) {
     // Conversion to fixed-size arrays happens once, up front - not timed.
     let trials_arr: Vec<(Vec<f64>, [f64; N])> = trials

--- a/examples/generated_ik.rs
+++ b/examples/generated_ik.rs
@@ -1,0 +1,33 @@
+use galaw::{error::GalawError, generated::simple_arm_2dof, load_urdf, types::GalawModel};
+
+fn main() -> Result<(), GalawError> {
+    let model: GalawModel = load_urdf("assets/urdf/custom/simple_arm_2dof.urdf")?;
+
+    // Command each actuated joint by name (note: we pass
+    // the array NOT vec since we know the params of the model)
+    let mut known_joint_cmds: [f64; 2] = [0.0; 2];
+    let shoulder_idx = model
+        .get_joint_idx("shoulder_joint")
+        .expect("shoulder_joint exists in URDF");
+    let elbow_idx = model
+        .get_joint_idx("elbow_joint")
+        .expect("elbow_joint exists in URDF");
+    known_joint_cmds[shoulder_idx] = 0.5;
+    known_joint_cmds[elbow_idx] = -0.3;
+
+    // Run FK computation using codegenerated file to get a target pose
+    let forearm_idx = model
+        .get_link_idx("forearm")
+        .expect("forearm link exists in URDF");
+    let target_pose = simple_arm_2dof::compute_fk(&known_joint_cmds)[forearm_idx];
+
+    // Solve IK from a different initial guess using codegenerated file
+    let init_joint_cmds: [f64; 2] = [0.0; 2];
+    let solved_joint_cmds =
+        simple_arm_2dof::compute_ik(forearm_idx, &target_pose, &init_joint_cmds)?;
+
+    println!("target pose: {:?}", target_pose);
+    println!("solved joint cmds: {:?}", solved_joint_cmds);
+
+    Ok(())
+}

--- a/examples/plot_ik_bench.rs
+++ b/examples/plot_ik_bench.rs
@@ -34,12 +34,11 @@ use galaw::{fixtures::BENCH_URDFS, load_urdf};
 /// are per iteration, so dividing by this converts to per single `compute_ik` call.
 const N_POSES: f64 = 100.0;
 
-/// No codegen counterpart for IK (see docs on `compute_ik`) — only the
-/// runtime solver and `k`'s own Jacobian IK solver are benchmarked.
-const IMPLS: [&str; 2] = ["galaw-runtime", "k"];
+const IMPLS: [&str; 3] = ["galaw-runtime", "galaw-generated", "k"];
 
-/// Wong (2011) colorblind-safe pair: galaw-runtime=blue, k=orange.
-const COLORS: [&str; 2] = ["#0072B2", "#E69F00"];
+/// Wong (2011) colorblind-safe triple, in series order: galaw-runtime=blue,
+/// galaw-generated=bluish green, k=orange.
+const COLORS: [&str; 3] = ["#0072B2", "#009E73", "#E69F00"];
 
 // ----- FONT SIZES (tweak here — every chart text element is driven off these) -----
 const TITLE_FONT_SIZE: f64 = 38.0;

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -1,7 +1,7 @@
 use std::env::args;
 
 // Third-party
-use nalgebra::{Translation3, UnitQuaternion, Vector3};
+use nalgebra::{Isometry3, Translation3, UnitQuaternion, Vector3};
 
 // Custom
 use galaw::{load_urdf, types::GalawModel};
@@ -407,10 +407,52 @@ fn generate_ik_fn_code(
         // (cmd_idx, pose var at this joint, world-frame axis var, is rotational)
         let mut actuated_steps: Vec<(usize, String, String, bool)> = Vec::new();
 
-        for (step, &joint_idx) in chain.iter().enumerate() {
-            let joint = &galaw_model.joints[joint_idx];
+        let mut pose_step: usize = 0;
+        let mut i = 0;
+        while i < chain.len() {
+            let joint = &galaw_model.joints[chain[i]];
 
-            // Using Unit::new_unchecked since already normalized in parser.rs
+            if joint.rot_axis.is_none() && joint.lin_axis.is_none() {
+                // Consecutive fixed joints don't depend on joint_cmds, so
+                // multiply their transforms together here (at codegen time)
+                // into one constant, instead of one runtime multiply each.
+                let mut combined = Isometry3::identity();
+                let mut j = i;
+                while j < chain.len() {
+                    let run_joint = &galaw_model.joints[chain[j]];
+                    if run_joint.rot_axis.is_some() || run_joint.lin_axis.is_some() {
+                        break;
+                    }
+                    combined = combined * run_joint.transform;
+                    j += 1;
+                }
+
+                let t_str = format!(
+                    "Translation3::new({:?}, {:?}, {:?})",
+                    combined.translation.x, combined.translation.y, combined.translation.z
+                );
+                let r_str = format!(
+                    "UnitQuaternion::from_quaternion(Quaternion::new({:?}, {:?}, {:?}, {:?}))",
+                    combined.rotation.w, combined.rotation.i, combined.rotation.j, combined.rotation.k
+                );
+                if let Some(constant) = optimize_joint_transform_code(
+                    &combined.translation,
+                    &combined.rotation,
+                    &t_str,
+                    &r_str,
+                ) {
+                    let new_pose_var = format!("pose_{}", pose_step);
+                    pose_step += 1;
+                    codegen_output
+                        .push(format!("let {} = {} * {};", new_pose_var, pose_var, constant));
+                    pose_var = new_pose_var;
+                }
+                i = j;
+                continue;
+            }
+
+            // Actuated joint: still one at a time, since its motion depends
+            // on joint_cmds at call time, not just codegen-time constants.
             let rotation: String = match joint.rot_axis {
                 Some(axis) => {
                     optimize_axis_angle_rotation_code(&axis.into_inner(), joint.cmd_idx.unwrap())
@@ -451,7 +493,6 @@ fn generate_ik_fn_code(
                 factors.push(jt);
             }
 
-            let is_fixed_joint = joint.rot_axis.is_none() && joint.lin_axis.is_none();
             let is_revolute_continous_joint = joint.rot_axis.is_some() && joint.lin_axis.is_none();
             let is_prismatic_joint = joint.lin_axis.is_some() && joint.rot_axis.is_none();
 
@@ -459,35 +500,33 @@ fn generate_ik_fn_code(
                 factors.push(rotation);
             } else if is_prismatic_joint {
                 factors.push(translation);
-            } else if !is_fixed_joint {
+            } else {
                 factors.push(format!(
                     "Isometry3::from_parts({}, {})",
                     translation, rotation
                 ));
             }
 
-            let new_pose_var = format!("pose_{}", step);
+            let new_pose_var = format!("pose_{}", pose_step);
+            let this_step = pose_step;
+            pose_step += 1;
             codegen_output.push(format!("let {} = {};", new_pose_var, factors.join(" * ")));
             pose_var = new_pose_var.clone();
 
-            if let Some(cmd_idx) = joint.cmd_idx {
-                let local_axis = joint
-                    .rot_axis
-                    .or(joint.lin_axis)
-                    .expect("actuated joint has an axis")
-                    .into_inner();
-                let axis_var = format!("axis_world_{}", step);
-                codegen_output.push(format!(
-                    "let {} = {}.rotation * Vector3::new({:?}, {:?}, {:?});",
-                    axis_var, new_pose_var, local_axis.x, local_axis.y, local_axis.z
-                ));
-                actuated_steps.push((
-                    cmd_idx,
-                    new_pose_var.clone(),
-                    axis_var,
-                    joint.rot_axis.is_some(),
-                ));
-            }
+            let cmd_idx = joint.cmd_idx.unwrap(); // actuated, so always Some
+            let local_axis = joint
+                .rot_axis
+                .or(joint.lin_axis)
+                .expect("actuated joint has an axis")
+                .into_inner();
+            let axis_var = format!("axis_world_{}", this_step);
+            codegen_output.push(format!(
+                "let {} = {}.rotation * Vector3::new({:?}, {:?}, {:?});",
+                axis_var, new_pose_var, local_axis.x, local_axis.y, local_axis.z
+            ));
+            actuated_steps.push((cmd_idx, new_pose_var.clone(), axis_var, joint.rot_axis.is_some()));
+
+            i += 1;
         }
 
         // Only a rotational joint's column needs the cross product below —

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -345,6 +345,10 @@ fn generate_ik_fn_code(
     codegen_output.push("const STEP_SIZE: f64 = 1.0;".to_string());
     codegen_output.push("const MAX_ITERATIONS: usize = 1000;".to_string());
 
+    // Loop-invariant, so computed once instead of every LM iteration.
+    codegen_output
+        .push("let damping_matrix = DAMPING_FACTOR * Matrix6::identity();".to_string());
+
     // Chain-independent, so hoisted above the match instead of duplicated per arm.
     codegen_output.push(
         "let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {".to_string(),
@@ -594,8 +598,7 @@ fn generate_ik_fn_code(
         // skip straight to the next pose/error recompute below.
         if !actuated_steps.is_empty() {
             codegen_output.push(
-                "let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();"
-                    .to_string(),
+                "let jjt_damped = jac * jac.transpose() + damping_matrix;".to_string(),
             );
             codegen_output.push(
                 "let x = jjt_damped.cholesky().expect(\"J*J^T + damping*I is always positive definite for damping > 0\").solve(&error);"

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -384,12 +384,15 @@ fn generate_ik_fn_code(
 
         codegen_output.push(format!("{} => {{", link_idx));
 
+        // Jacobian is sized to this chain's own actuated joints, not `n` —
+        // most links only touch a fraction of the model's total DOF.
+        let chain_actuated_count = chain
+            .iter()
+            .filter(|&&joint_idx| galaw_model.joints[joint_idx].cmd_idx.is_some())
+            .count();
         // An all-fixed chain never emits a `joint_cmds[cmd_idx]` reference,
         // so avoid an unused-variable warning on the closure param.
-        let chain_has_actuated_joint = chain
-            .iter()
-            .any(|&joint_idx| galaw_model.joints[joint_idx].cmd_idx.is_some());
-        let joint_cmds_param = if chain_has_actuated_joint {
+        let joint_cmds_param = if chain_actuated_count > 0 {
             "joint_cmds"
         } else {
             "_joint_cmds"
@@ -397,7 +400,7 @@ fn generate_ik_fn_code(
 
         codegen_output.push(format!(
             "let compute_pose_and_jacobian = |{}: &[f64; {}]| -> (Isometry3<f64>, SMatrix<f64, 6, {}>) {{",
-            joint_cmds_param, n, n
+            joint_cmds_param, n, chain_actuated_count
         ));
 
         let mut pose_var = "Isometry3::identity()".to_string();
@@ -498,10 +501,14 @@ fn generate_ik_fn_code(
         let jac_mut_keyword = if actuated_steps.is_empty() { "" } else { "mut " };
         codegen_output.push(format!(
             "let {}jac = SMatrix::<f64, 6, {}>::zeros();",
-            jac_mut_keyword, n
+            jac_mut_keyword, chain_actuated_count
         ));
 
-        for (cmd_idx, joint_pose_var, axis_var, is_rot) in &actuated_steps {
+        // Column index is this step's position within the chain, not its
+        // global cmd_idx — jac is only chain_actuated_count wide now.
+        for (local_col, (_cmd_idx, joint_pose_var, axis_var, is_rot)) in
+            actuated_steps.iter().enumerate()
+        {
             let (lin_expr, ang_expr) = if *is_rot {
                 (
                     format!(
@@ -514,7 +521,7 @@ fn generate_ik_fn_code(
                 (axis_var.clone(), "Vector3::zeros()".to_string())
             };
             codegen_output.push(format!(
-                "{{ let lin = {lin_expr}; let ang = {ang_expr}; jac.set_column({cmd_idx}, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }}"
+                "{{ let lin = {lin_expr}; let ang = {ang_expr}; jac.set_column({local_col}, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }}"
             ));
         }
 
@@ -522,10 +529,18 @@ fn generate_ik_fn_code(
         codegen_output.push("};".to_string());
 
         // LM loop is identical across arms (only `n` varies), so it isn't unrolled.
-        codegen_output.push(
-            "let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);"
-                .to_string(),
-        );
+        // `jac`/`new_jac` only get read inside the `if !actuated_steps.is_empty()`
+        // block below, so when it's empty, underscore-prefix them too — otherwise
+        // they'd be dead stores every loop iteration.
+        let (jac_binding, new_jac_binding) = if actuated_steps.is_empty() {
+            ("_jac", "_new_jac")
+        } else {
+            ("jac", "new_jac")
+        };
+        codegen_output.push(format!(
+            "let (mut current_pose, mut {}) = compute_pose_and_jacobian(&joint_cmds);",
+            jac_binding
+        ));
         codegen_output.push("let mut error = compute_error(&current_pose);".to_string());
         codegen_output.push("let mut iterations: usize = 0;".to_string());
         codegen_output.push("while error.norm() > ERROR_TOLERANCE {".to_string());
@@ -535,26 +550,37 @@ fn generate_ik_fn_code(
                 .to_string(),
         );
         codegen_output.push("}".to_string());
-        codegen_output.push(
-            "let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();"
-                .to_string(),
-        );
-        codegen_output.push(
-            "let x = jjt_damped.cholesky().expect(\"J*J^T + damping*I is always positive definite for damping > 0\").solve(&error);"
-                .to_string(),
-        );
+        // No actuated joints in this chain means jac is always zero, so the
+        // whole solve is a no-op (and every binding here would be unused) —
+        // skip straight to the next pose/error recompute below.
+        if !actuated_steps.is_empty() {
+            codegen_output.push(
+                "let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();"
+                    .to_string(),
+            );
+            codegen_output.push(
+                "let x = jjt_damped.cholesky().expect(\"J*J^T + damping*I is always positive definite for damping > 0\").solve(&error);"
+                    .to_string(),
+            );
+            codegen_output.push(format!(
+                "let dq: SVector<f64, {}> = jac.transpose() * x;",
+                chain_actuated_count
+            ));
+            // dq is chain-local (see jac above), so scatter each entry back
+            // to its actuated joint's own global cmd_idx individually.
+            for (local_col, (cmd_idx, _, _, _)) in actuated_steps.iter().enumerate() {
+                codegen_output.push(format!(
+                    "joint_cmds[{}] += STEP_SIZE * dq[{}];",
+                    cmd_idx, local_col
+                ));
+            }
+        }
         codegen_output.push(format!(
-            "let dq: SVector<f64, {}> = jac.transpose() * x;",
-            n
+            "let (pose, {}) = compute_pose_and_jacobian(&joint_cmds);",
+            new_jac_binding
         ));
-        codegen_output.push(
-            "for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }"
-                .to_string(),
-        );
-        codegen_output
-            .push("let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);".to_string());
         codegen_output.push("current_pose = pose;".to_string());
-        codegen_output.push("jac = new_jac;".to_string());
+        codegen_output.push(format!("{} = {};", jac_binding, new_jac_binding));
         codegen_output.push("error = compute_error(&current_pose);".to_string());
         codegen_output.push("iterations += 1;".to_string());
         codegen_output.push("}".to_string());

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -224,6 +224,7 @@ fn generate_fk_fn_code(
     Ok(codegen_output)
 }
 
+/// Generates Jacobian function code.
 fn generate_jacobian_fn_code(
     galaw_model: &GalawModel,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -318,6 +319,280 @@ fn generate_jacobian_fn_code(
     Ok(codegen_output)
 }
 
+/// Generates inverse-kinematics function code.
+fn generate_ik_fn_code(
+    galaw_model: &GalawModel,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut codegen_output: Vec<String> = Vec::new();
+
+    codegen_output.push("use nalgebra::{SVector, Matrix6};".to_string());
+    codegen_output.push("use crate::error::KinematicsError;".to_string());
+
+    let n = galaw_model.num_actuated_joints;
+
+    codegen_output.push(format!(
+        "/// Computes inverse kinematics for the robot described by `{}`.",
+        galaw_model.name
+    ));
+    codegen_output.push("#[allow(non_snake_case)]".to_string());
+    codegen_output.push("#[rustfmt::skip]".to_string());
+    codegen_output.push(format!(
+        "pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; {}]) -> Result<[f64; {}], KinematicsError> {{",
+        n, n
+    ));
+    codegen_output.push("const ERROR_TOLERANCE: f64 = 1e-5;".to_string());
+    codegen_output.push("const DAMPING_FACTOR: f64 = 1e-4;".to_string());
+    codegen_output.push("const STEP_SIZE: f64 = 1.0;".to_string());
+    codegen_output.push("const MAX_ITERATIONS: usize = 1000;".to_string());
+
+    // Shared by every arm below — doesn't depend on the chain.
+    codegen_output.push(
+        "let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {".to_string(),
+    );
+    codegen_output.push(
+        "let error_position = target_pose.translation.vector - current_pose.translation.vector;"
+            .to_string(),
+    );
+    codegen_output.push(
+        "let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();"
+            .to_string(),
+    );
+    codegen_output.push(
+        "Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)"
+            .to_string(),
+    );
+    codegen_output.push("};".to_string());
+
+    codegen_output.push("let mut joint_cmds = *initial_joint_cmds;".to_string());
+    codegen_output.push("match target_link_idx {".to_string());
+
+    for link_idx in 0..galaw_model.links.len() {
+        // Walk the chain from root to this link (same approach as
+        // `GalawModel::compute_ik`), so it can be baked in below.
+        let mut chain: Vec<usize> = Vec::new();
+        let mut walk_link_idx = link_idx;
+        while let Some(&joint_idx) = galaw_model.link_idx_to_parent_joint_idx.get(&walk_link_idx) {
+            chain.push(joint_idx);
+            walk_link_idx = galaw_model.joints[joint_idx].parent_link_idx;
+        }
+        chain.reverse();
+
+        // Empty only for the root link — handled by the `_` arm below,
+        // same as the runtime function falling out of its chain-walk loop
+        // immediately for a link with no parent.
+        if chain.is_empty() {
+            continue;
+        }
+
+        codegen_output.push(format!("{} => {{", link_idx));
+
+        // A chain of entirely fixed joints never indexes into `joint_cmds`
+        // (every rotation/translation factor below resolves to `::identity()`
+        // — `joint_cmds[cmd_idx]` is only ever emitted for a joint that has
+        // an axis, i.e. one with `cmd_idx.is_some()`), so name the closure
+        // param `_joint_cmds` in that case to avoid an unused-variable warning.
+        let chain_has_actuated_joint = chain
+            .iter()
+            .any(|&joint_idx| galaw_model.joints[joint_idx].cmd_idx.is_some());
+        let joint_cmds_param = if chain_has_actuated_joint {
+            "joint_cmds"
+        } else {
+            "_joint_cmds"
+        };
+
+        // Closure computing this link's pose and Jacobian for a given
+        // joint_cmds, with the chain fully unrolled.
+        codegen_output.push(format!(
+            "let compute_pose_and_jacobian = |{}: &[f64; {}]| -> (Isometry3<f64>, SMatrix<f64, 6, {}>) {{",
+            joint_cmds_param, n, n
+        ));
+
+        let mut pose_var = "Isometry3::identity()".to_string();
+        // (cmd_idx, pose var at this joint, world-frame axis var, is rotational)
+        let mut actuated_steps: Vec<(usize, String, String, bool)> = Vec::new();
+
+        for (step, &joint_idx) in chain.iter().enumerate() {
+            let joint = &galaw_model.joints[joint_idx];
+
+            // Using Unit::new_unchecked since already normalized in parser.rs
+            let rotation: String = match joint.rot_axis {
+                Some(axis) => {
+                    optimize_axis_angle_rotation_code(&axis.into_inner(), joint.cmd_idx.unwrap())
+                }
+                None => "UnitQuaternion::identity()".to_string(),
+            };
+            let translation: String = match joint.lin_axis {
+                Some(axis) => {
+                    let vec = axis.into_inner();
+                    let axis_vec_str: String =
+                        format!("Vector3::new({:?}, {:?}, {:?})", vec.x, vec.y, vec.z);
+                    format!(
+                        "Translation3::from({} * joint_cmds[{}])",
+                        axis_vec_str,
+                        joint.cmd_idx.unwrap()
+                    )
+                }
+                None => "Translation3::identity()".to_string(),
+            };
+            let joint_transform_t = &joint.transform.translation;
+            let joint_transform_t_str: String = format!(
+                "Translation3::new({:?}, {:?}, {:?})",
+                joint_transform_t.x, joint_transform_t.y, joint_transform_t.z
+            );
+            let joint_transform_r = &joint.transform.rotation;
+            let joint_transform_r_str: String = format!(
+                "UnitQuaternion::from_quaternion(Quaternion::new({:?}, {:?}, {:?}, {:?}))",
+                joint_transform_r.w, joint_transform_r.i, joint_transform_r.j, joint_transform_r.k
+            );
+
+            let mut factors: Vec<String> = vec![pose_var.clone()];
+            if let Some(jt) = optimize_joint_transform_code(
+                joint_transform_t,
+                joint_transform_r,
+                &joint_transform_t_str,
+                &joint_transform_r_str,
+            ) {
+                factors.push(jt);
+            }
+
+            let is_fixed_joint = joint.rot_axis.is_none() && joint.lin_axis.is_none();
+            let is_revolute_continous_joint = joint.rot_axis.is_some() && joint.lin_axis.is_none();
+            let is_prismatic_joint = joint.lin_axis.is_some() && joint.rot_axis.is_none();
+
+            if is_revolute_continous_joint {
+                factors.push(rotation);
+            } else if is_prismatic_joint {
+                factors.push(translation);
+            } else if !is_fixed_joint {
+                factors.push(format!(
+                    "Isometry3::from_parts({}, {})",
+                    translation, rotation
+                ));
+            }
+
+            let new_pose_var = format!("pose_{}", step);
+            codegen_output.push(format!("let {} = {};", new_pose_var, factors.join(" * ")));
+            pose_var = new_pose_var.clone();
+
+            if let Some(cmd_idx) = joint.cmd_idx {
+                let local_axis = joint
+                    .rot_axis
+                    .or(joint.lin_axis)
+                    .expect("actuated joint has an axis")
+                    .into_inner();
+                let axis_var = format!("axis_world_{}", step);
+                codegen_output.push(format!(
+                    "let {} = {}.rotation * Vector3::new({:?}, {:?}, {:?});",
+                    axis_var, new_pose_var, local_axis.x, local_axis.y, local_axis.z
+                ));
+                actuated_steps.push((
+                    cmd_idx,
+                    new_pose_var.clone(),
+                    axis_var,
+                    joint.rot_axis.is_some(),
+                ));
+            }
+        }
+
+        // `target_position` is only read below for a *rotational* actuated
+        // joint (the cross-product for its linear velocity column) — a
+        // prismatic joint's column is just its axis, no cross product.
+        let chain_has_rotational_actuated_joint =
+            actuated_steps.iter().any(|(_, _, _, is_rot)| *is_rot);
+        if chain_has_rotational_actuated_joint {
+            codegen_output.push(format!("let target_position = {}.translation;", pose_var));
+        }
+        // Only `mut` when there's an actuated joint to `set_column` below —
+        // otherwise `jac` is never mutated and `mut` itself would warn.
+        let jac_mut_keyword = if actuated_steps.is_empty() { "" } else { "mut " };
+        codegen_output.push(format!(
+            "let {}jac = SMatrix::<f64, 6, {}>::zeros();",
+            jac_mut_keyword, n
+        ));
+
+        for (cmd_idx, joint_pose_var, axis_var, is_rot) in &actuated_steps {
+            let (lin_expr, ang_expr) = if *is_rot {
+                (
+                    format!(
+                        "{}.cross(&(target_position.vector - {}.translation.vector))",
+                        axis_var, joint_pose_var
+                    ),
+                    axis_var.clone(),
+                )
+            } else {
+                (axis_var.clone(), "Vector3::zeros()".to_string())
+            };
+            codegen_output.push(format!(
+                "{{ let lin = {lin_expr}; let ang = {ang_expr}; jac.set_column({cmd_idx}, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }}"
+            ));
+        }
+
+        codegen_output.push(format!("({}, jac)", pose_var));
+        codegen_output.push("};".to_string());
+
+        // The Levenberg-Marquardt loop itself: identical shape in every
+        // arm, so this part isn't unrolled — only `n` varies.
+        codegen_output.push(
+            "let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);"
+                .to_string(),
+        );
+        codegen_output.push("let mut error = compute_error(&current_pose);".to_string());
+        codegen_output.push("let mut iterations: usize = 0;".to_string());
+        codegen_output.push("while error.norm() > ERROR_TOLERANCE {".to_string());
+        codegen_output.push("if iterations >= MAX_ITERATIONS {".to_string());
+        codegen_output.push(
+            "return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });"
+                .to_string(),
+        );
+        codegen_output.push("}".to_string());
+        codegen_output.push(
+            "let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();"
+                .to_string(),
+        );
+        codegen_output.push(
+            "let x = jjt_damped.cholesky().expect(\"J*J^T + damping*I is always positive definite for damping > 0\").solve(&error);"
+                .to_string(),
+        );
+        codegen_output.push(format!(
+            "let dq: SVector<f64, {}> = jac.transpose() * x;",
+            n
+        ));
+        codegen_output.push(
+            "for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }"
+                .to_string(),
+        );
+        codegen_output
+            .push("let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);".to_string());
+        codegen_output.push("current_pose = pose;".to_string());
+        codegen_output.push("jac = new_jac;".to_string());
+        codegen_output.push("error = compute_error(&current_pose);".to_string());
+        codegen_output.push("iterations += 1;".to_string());
+        codegen_output.push("}".to_string());
+        codegen_output.push("Ok(joint_cmds)".to_string());
+        codegen_output.push("}".to_string()); // closes this match arm
+    }
+
+    // Fallback for the root link (empty chain) and any out-of-range
+    // target_link_idx: pose is always identity, and since a zero Jacobian
+    // can never move joint_cmds, there's no LM iteration to unroll — just
+    // check once whether target_pose is already reached.
+    codegen_output.push("_ => {".to_string());
+    codegen_output.push("let error = compute_error(&Isometry3::identity());".to_string());
+    codegen_output.push("if error.norm() > ERROR_TOLERANCE {".to_string());
+    codegen_output.push(
+        "return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });"
+            .to_string(),
+    );
+    codegen_output.push("}".to_string());
+    codegen_output.push("Ok(joint_cmds)".to_string());
+    codegen_output.push("}".to_string()); // closes fallback arm
+
+    codegen_output.push("}".to_string()); // closes match
+    codegen_output.push("}".to_string()); // closes fn
+
+    Ok(codegen_output)
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = args().collect();
 
@@ -327,6 +602,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut codegen_output = generate_fk_fn_code(urdf_path, &galaw_model)?;
     codegen_output.extend(generate_jacobian_fn_code(&galaw_model)?);
+    codegen_output.extend(generate_ik_fn_code(&galaw_model)?);
     let codegen: String = codegen_output.join("\n");
 
     // Creating directory if it's missing

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -345,7 +345,7 @@ fn generate_ik_fn_code(
     codegen_output.push("const STEP_SIZE: f64 = 1.0;".to_string());
     codegen_output.push("const MAX_ITERATIONS: usize = 1000;".to_string());
 
-    // Shared by every arm below — doesn't depend on the chain.
+    // Chain-independent, so hoisted above the match instead of duplicated per arm.
     codegen_output.push(
         "let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {".to_string(),
     );
@@ -377,20 +377,15 @@ fn generate_ik_fn_code(
         }
         chain.reverse();
 
-        // Empty only for the root link — handled by the `_` arm below,
-        // same as the runtime function falling out of its chain-walk loop
-        // immediately for a link with no parent.
+        // Empty only for the root link — the `_` arm below covers it.
         if chain.is_empty() {
             continue;
         }
 
         codegen_output.push(format!("{} => {{", link_idx));
 
-        // A chain of entirely fixed joints never indexes into `joint_cmds`
-        // (every rotation/translation factor below resolves to `::identity()`
-        // — `joint_cmds[cmd_idx]` is only ever emitted for a joint that has
-        // an axis, i.e. one with `cmd_idx.is_some()`), so name the closure
-        // param `_joint_cmds` in that case to avoid an unused-variable warning.
+        // An all-fixed chain never emits a `joint_cmds[cmd_idx]` reference,
+        // so avoid an unused-variable warning on the closure param.
         let chain_has_actuated_joint = chain
             .iter()
             .any(|&joint_idx| galaw_model.joints[joint_idx].cmd_idx.is_some());
@@ -400,8 +395,6 @@ fn generate_ik_fn_code(
             "_joint_cmds"
         };
 
-        // Closure computing this link's pose and Jacobian for a given
-        // joint_cmds, with the chain fully unrolled.
         codegen_output.push(format!(
             "let compute_pose_and_jacobian = |{}: &[f64; {}]| -> (Isometry3<f64>, SMatrix<f64, 6, {}>) {{",
             joint_cmds_param, n, n
@@ -494,16 +487,14 @@ fn generate_ik_fn_code(
             }
         }
 
-        // `target_position` is only read below for a *rotational* actuated
-        // joint (the cross-product for its linear velocity column) — a
-        // prismatic joint's column is just its axis, no cross product.
+        // Only a rotational joint's column needs the cross product below —
+        // skip emitting `target_position` otherwise, or it'd go unused.
         let chain_has_rotational_actuated_joint =
             actuated_steps.iter().any(|(_, _, _, is_rot)| *is_rot);
         if chain_has_rotational_actuated_joint {
             codegen_output.push(format!("let target_position = {}.translation;", pose_var));
         }
-        // Only `mut` when there's an actuated joint to `set_column` below —
-        // otherwise `jac` is never mutated and `mut` itself would warn.
+        // Same reasoning for `mut`: no actuated joint means no `set_column` call.
         let jac_mut_keyword = if actuated_steps.is_empty() { "" } else { "mut " };
         codegen_output.push(format!(
             "let {}jac = SMatrix::<f64, 6, {}>::zeros();",
@@ -530,8 +521,7 @@ fn generate_ik_fn_code(
         codegen_output.push(format!("({}, jac)", pose_var));
         codegen_output.push("};".to_string());
 
-        // The Levenberg-Marquardt loop itself: identical shape in every
-        // arm, so this part isn't unrolled — only `n` varies.
+        // LM loop is identical across arms (only `n` varies), so it isn't unrolled.
         codegen_output.push(
             "let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);"
                 .to_string(),
@@ -572,10 +562,8 @@ fn generate_ik_fn_code(
         codegen_output.push("}".to_string()); // closes this match arm
     }
 
-    // Fallback for the root link (empty chain) and any out-of-range
-    // target_link_idx: pose is always identity, and since a zero Jacobian
-    // can never move joint_cmds, there's no LM iteration to unroll — just
-    // check once whether target_pose is already reached.
+    // Root link / out-of-range index: pose is identity and the Jacobian is
+    // always zero, so joint_cmds can never move — just check once.
     codegen_output.push("_ => {".to_string());
     codegen_output.push("let error = compute_error(&Isometry3::identity());".to_string());
     codegen_output.push("if error.norm() > ERROR_TOLERANCE {".to_string());

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -346,13 +346,11 @@ fn generate_ik_fn_code(
     codegen_output.push("const MAX_ITERATIONS: usize = 1000;".to_string());
 
     // Loop-invariant, so computed once instead of every LM iteration.
-    codegen_output
-        .push("let damping_matrix = DAMPING_FACTOR * Matrix6::identity();".to_string());
+    codegen_output.push("let damping_matrix = DAMPING_FACTOR * Matrix6::identity();".to_string());
 
     // Chain-independent, so hoisted above the match instead of duplicated per arm.
-    codegen_output.push(
-        "let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {".to_string(),
-    );
+    codegen_output
+        .push("let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {".to_string());
     codegen_output.push(
         "let error_position = target_pose.translation.vector - current_pose.translation.vector;"
             .to_string(),
@@ -437,7 +435,10 @@ fn generate_ik_fn_code(
                 );
                 let r_str = format!(
                     "UnitQuaternion::from_quaternion(Quaternion::new({:?}, {:?}, {:?}, {:?}))",
-                    combined.rotation.w, combined.rotation.i, combined.rotation.j, combined.rotation.k
+                    combined.rotation.w,
+                    combined.rotation.i,
+                    combined.rotation.j,
+                    combined.rotation.k
                 );
                 if let Some(constant) = optimize_joint_transform_code(
                     &combined.translation,
@@ -447,8 +448,10 @@ fn generate_ik_fn_code(
                 ) {
                     let new_pose_var = format!("pose_{}", pose_step);
                     pose_step += 1;
-                    codegen_output
-                        .push(format!("let {} = {} * {};", new_pose_var, pose_var, constant));
+                    codegen_output.push(format!(
+                        "let {} = {} * {};",
+                        new_pose_var, pose_var, constant
+                    ));
                     pose_var = new_pose_var;
                 }
                 i = j;
@@ -528,7 +531,12 @@ fn generate_ik_fn_code(
                 "let {} = {}.rotation * Vector3::new({:?}, {:?}, {:?});",
                 axis_var, new_pose_var, local_axis.x, local_axis.y, local_axis.z
             ));
-            actuated_steps.push((cmd_idx, new_pose_var.clone(), axis_var, joint.rot_axis.is_some()));
+            actuated_steps.push((
+                cmd_idx,
+                new_pose_var.clone(),
+                axis_var,
+                joint.rot_axis.is_some(),
+            ));
 
             i += 1;
         }
@@ -541,7 +549,11 @@ fn generate_ik_fn_code(
             codegen_output.push(format!("let target_position = {}.translation;", pose_var));
         }
         // Same reasoning for `mut`: no actuated joint means no `set_column` call.
-        let jac_mut_keyword = if actuated_steps.is_empty() { "" } else { "mut " };
+        let jac_mut_keyword = if actuated_steps.is_empty() {
+            ""
+        } else {
+            "mut "
+        };
         codegen_output.push(format!(
             "let {}jac = SMatrix::<f64, 6, {}>::zeros();",
             jac_mut_keyword, chain_actuated_count
@@ -597,9 +609,8 @@ fn generate_ik_fn_code(
         // whole solve is a no-op (and every binding here would be unused) —
         // skip straight to the next pose/error recompute below.
         if !actuated_steps.is_empty() {
-            codegen_output.push(
-                "let jjt_damped = jac * jac.transpose() + damping_matrix;".to_string(),
-            );
+            codegen_output
+                .push("let jjt_damped = jac * jac.transpose() + damping_matrix;".to_string());
             codegen_output.push(
                 "let x = jjt_damped.cholesky().expect(\"J*J^T + damping*I is always positive definite for damping > 0\").solve(&error);"
                     .to_string(),

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -425,7 +425,7 @@ fn generate_ik_fn_code(
                     if run_joint.rot_axis.is_some() || run_joint.lin_axis.is_some() {
                         break;
                     }
-                    combined = combined * run_joint.transform;
+                    combined *= run_joint.transform;
                     j += 1;
                 }
 

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -317,3 +317,2941 @@ let mut jacobian_inspection_payload_microphone = SMatrix::<f64, 6, 14>::zeros();
 let jacobian_inspection_payload_camera_default = SMatrix::<f64, 6, 14>::zeros();
 [jacobian_base, jacobian_base_inertia, jacobian_body_top, jacobian_top_shell, jacobian_bottom_shell, jacobian_face_front, jacobian_depth_camera_front_lower_camera, jacobian_depth_camera_front_lower_camera_parent, jacobian_depth_camera_front_lower_depth_frame, jacobian_depth_camera_front_lower_depth_optical_frame, jacobian_depth_camera_front_upper_camera, jacobian_depth_camera_front_upper_camera_parent, jacobian_depth_camera_front_upper_depth_frame, jacobian_depth_camera_front_upper_depth_optical_frame, jacobian_wide_angle_camera_front_camera, jacobian_wide_angle_camera_front_camera_parent, jacobian_face_rear, jacobian_depth_camera_rear_lower_camera, jacobian_depth_camera_rear_lower_camera_parent, jacobian_depth_camera_rear_lower_depth_frame, jacobian_depth_camera_rear_lower_depth_optical_frame, jacobian_depth_camera_rear_upper_camera, jacobian_depth_camera_rear_upper_camera_parent, jacobian_depth_camera_rear_upper_depth_frame, jacobian_depth_camera_rear_upper_depth_optical_frame, jacobian_wide_angle_camera_rear_camera, jacobian_wide_angle_camera_rear_camera_parent, jacobian_face_shell_front, jacobian_face_shell_rear, jacobian_battery, jacobian_docking_socket, jacobian_hbc_receiver, jacobian_imu_link, jacobian_depth_camera_left_camera, jacobian_depth_camera_left_camera_parent, jacobian_depth_camera_left_depth_frame, jacobian_depth_camera_left_depth_optical_frame, jacobian_depth_camera_right_camera, jacobian_depth_camera_right_camera_parent, jacobian_depth_camera_right_depth_frame, jacobian_depth_camera_right_depth_optical_frame, jacobian_lidar_parent, jacobian_lidar, jacobian_LF_HAA_drive, jacobian_LF_HIP, jacobian_LF_hip_fixed, jacobian_LF_HFE_output, jacobian_LF_HFE_drive, jacobian_LF_THIGH, jacobian_LF_thigh_fixed, jacobian_LF_KFE_drive, jacobian_LF_SHANK, jacobian_LF_shank_fixed, jacobian_LF_FOOT, jacobian_RF_HAA_drive, jacobian_RF_HIP, jacobian_RF_hip_fixed, jacobian_RF_HFE_output, jacobian_RF_HFE_drive, jacobian_RF_THIGH, jacobian_RF_thigh_fixed, jacobian_RF_KFE_drive, jacobian_RF_SHANK, jacobian_RF_shank_fixed, jacobian_RF_FOOT, jacobian_LH_HAA_drive, jacobian_LH_HIP, jacobian_LH_hip_fixed, jacobian_LH_HFE_output, jacobian_LH_HFE_drive, jacobian_LH_THIGH, jacobian_LH_thigh_fixed, jacobian_LH_KFE_drive, jacobian_LH_SHANK, jacobian_LH_shank_fixed, jacobian_LH_FOOT, jacobian_RH_HAA_drive, jacobian_RH_HIP, jacobian_RH_hip_fixed, jacobian_RH_HFE_output, jacobian_RH_HFE_drive, jacobian_RH_THIGH, jacobian_RH_thigh_fixed, jacobian_RH_KFE_drive, jacobian_RH_SHANK, jacobian_RH_shank_fixed, jacobian_RH_FOOT, jacobian_inspection_payload_mount, jacobian_inspection_payload_pan, jacobian_inspection_payload_tilt, jacobian_inspection_payload_head, jacobian_inspection_payload_camera, jacobian_inspection_payload_thermal_camera, jacobian_inspection_payload_light, jacobian_inspection_payload_microphone, jacobian_inspection_payload_camera_default]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `anymal-D`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 14]) -> Result<[f64; 14], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity();
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.144);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+3 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity();
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+4 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity();
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+5 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+6 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+7 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+8 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+9 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+10 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+11 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+12 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+13 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+14 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+15 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+16 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+17 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+18 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+19 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+20 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+21 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+22 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+23 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+24 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_3 = pose_2;
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+25 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+26 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+27 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+28 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+29 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity();
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+30 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.26132, 0.0, -0.06205);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+31 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0435, 0.0, 0.144);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+32 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.25565, 0.00255, 0.07672), UnitQuaternion::from_quaternion(Quaternion::new(3.749399456654644e-33, 6.123233995736766e-17, 1.0, 6.123233995736766e-17)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+33 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+34 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+35 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
+let pose_1 = pose_0;
+let pose_2 = pose_1;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+36 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
+let pose_1 = pose_0;
+let pose_2 = pose_1;
+let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+37 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+38 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+39 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
+let pose_1 = pose_0;
+let pose_2 = pose_1;
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+40 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
+let pose_1 = pose_0;
+let pose_2 = pose_1;
+let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+41 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+42 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_1 = pose_0 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+43 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+44 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+45 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+46 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+47 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let target_position = pose_5.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+48 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+49 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_6.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+50 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_7.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+51 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_8.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+52 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_9.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+53 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_10 = pose_9 * Translation3::new(0.1, 0.02225, -0.39246);
+let target_position = pose_10.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+54 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+55 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+56 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+57 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+58 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let target_position = pose_5.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+59 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+60 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_6.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+61 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_7.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+62 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_8.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+63 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_9.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+64 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_2 = pose_1;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_10 = pose_9 * Translation3::new(0.1, -0.02225, -0.39246);
+let target_position = pose_10.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+65 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+66 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+67 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+68 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+69 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let target_position = pose_5.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+70 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+71 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_6.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+72 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_7.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+73 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_8.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+74 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_9.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+75 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_10 = pose_9 * Translation3::new(-0.1, 0.02225, -0.39246);
+let target_position = pose_10.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+76 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+77 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+78 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+79 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+80 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let target_position = pose_5.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+81 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+82 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_6.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+83 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_7.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+84 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_8.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+85 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_9.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+86 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
+let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4;
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_10 = pose_9 * Translation3::new(-0.1, -0.02225, -0.39246);
+let target_position = pose_10.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+87 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+88 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+89 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+90 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2;
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+91 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2;
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.055, -0.023, 0.031), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+92 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2;
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, -0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+93 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2;
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.05495, 0.03, 0.03116), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+94 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2;
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, 0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 14>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+95 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.175);
+let jac = SMatrix::<f64, 6, 14>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 14> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -336,9 +336,8 @@ let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity();
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_0, jac)
+(Isometry3::identity(), jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -378,9 +377,8 @@ Ok(joint_cmds)
 }
 3 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity();
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_0, jac)
+(Isometry3::identity(), jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -399,9 +397,8 @@ Ok(joint_cmds)
 }
 4 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity();
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_0, jac)
+(Isometry3::identity(), jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -441,10 +438,9 @@ Ok(joint_cmds)
 }
 6 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.36842, -0.025, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -463,11 +459,9 @@ Ok(joint_cmds)
 }
 7 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.36842, -0.025, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(5.3028761936245346e-17, 0.8660254037844387, 3.0616169978683824e-17, -0.49999999999999994)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -486,12 +480,9 @@ Ok(joint_cmds)
 }
 8 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.36842, -0.025, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(5.3028761936245346e-17, 0.8660254037844387, 3.0616169978683824e-17, -0.49999999999999994)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -510,13 +501,9 @@ Ok(joint_cmds)
 }
 9 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
-let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.36842, -0.025, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(0.18301270189221938, 0.6830127018922194, 0.6830127018922193, 0.18301270189221924)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_4, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -535,10 +522,9 @@ Ok(joint_cmds)
 }
 10 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.39877, -0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -557,11 +543,9 @@ Ok(joint_cmds)
 }
 11 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.39877, -0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(6.070848880062641e-17, 0.9914448613738104, 7.992424175358916e-18, -0.13052619222005157)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -580,12 +564,9 @@ Ok(joint_cmds)
 }
 12 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.39877, -0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(6.070848880062641e-17, 0.9914448613738104, 7.992424175358916e-18, -0.13052619222005157)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -604,13 +585,9 @@ Ok(joint_cmds)
 }
 13 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
-let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.39877, -0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(0.43045933457687946, 0.560985526796931, 0.560985526796931, 0.43045933457687924)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_4, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -630,9 +607,8 @@ Ok(joint_cmds)
 14 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -651,11 +627,9 @@ Ok(joint_cmds)
 }
 15 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0;
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.40449, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -695,10 +669,9 @@ Ok(joint_cmds)
 }
 17 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.36842, 0.024999999999999994, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(5.3028761936245346e-17, -0.49999999999999994, 3.0616169978683824e-17, 0.8660254037844387)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -717,11 +690,9 @@ Ok(joint_cmds)
 }
 18 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.36842, 0.024999999999999994, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999994, 2.2412591957561522e-17, 0.8660254037844387, 2.2412591957561522e-17)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -740,12 +711,9 @@ Ok(joint_cmds)
 }
 19 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.36842, 0.024999999999999994, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999994, 2.2412591957561522e-17, 0.8660254037844387, 2.2412591957561522e-17)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -764,13 +732,9 @@ Ok(joint_cmds)
 }
 20 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
-let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.36842, 0.024999999999999994, -0.060009999999999994), UnitQuaternion::from_quaternion(Quaternion::new(-0.18301270189221924, -0.6830127018922193, 0.6830127018922194, 0.18301270189221938)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_4, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -789,10 +753,9 @@ Ok(joint_cmds)
 }
 21 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.39877, 0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(6.070848880062641e-17, -0.13052619222005157, 7.992424175358916e-18, 0.9914448613738104)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -811,11 +774,9 @@ Ok(joint_cmds)
 }
 22 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.39877, 0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(0.13052619222005157, 5.2716064625267493e-17, 0.9914448613738104, 5.2716064625267493e-17)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -834,12 +795,9 @@ Ok(joint_cmds)
 }
 23 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.39877, 0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(0.13052619222005157, 5.2716064625267493e-17, 0.9914448613738104, 5.2716064625267493e-17)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -858,13 +816,9 @@ Ok(joint_cmds)
 }
 24 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let pose_3 = pose_2;
-let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.39877, 0.025, -0.020460000000000002), UnitQuaternion::from_quaternion(Quaternion::new(-0.43045933457687924, -0.5609855267969309, 0.5609855267969311, 0.43045933457687946)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_4, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -884,9 +838,8 @@ Ok(joint_cmds)
 25 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -905,11 +858,9 @@ Ok(joint_cmds)
 }
 26 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0;
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.40449, -5.155763024410357e-19, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(0.5, -0.49999999999999994, -0.49999999999999994, 0.5000000000000001)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -929,9 +880,8 @@ Ok(joint_cmds)
 27 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -951,9 +901,8 @@ Ok(joint_cmds)
 28 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -972,9 +921,8 @@ Ok(joint_cmds)
 }
 29 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity();
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_0, jac)
+(Isometry3::identity(), jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1078,9 +1026,8 @@ Ok(joint_cmds)
 34 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1100,10 +1047,8 @@ Ok(joint_cmds)
 35 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
-let pose_1 = pose_0;
-let pose_2 = pose_1;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1122,12 +1067,9 @@ Ok(joint_cmds)
 }
 36 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
-let pose_1 = pose_0;
-let pose_2 = pose_1;
-let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.40673664307580026, -0.9135454576426008, 5.551115123125783e-17, 5.551115123125783e-17)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1168,9 +1110,8 @@ Ok(joint_cmds)
 38 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1190,10 +1131,8 @@ Ok(joint_cmds)
 39 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
-let pose_1 = pose_0;
-let pose_2 = pose_1;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1212,12 +1151,9 @@ Ok(joint_cmds)
 }
 40 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
-let pose_1 = pose_0;
-let pose_2 = pose_1;
-let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(1.1102230246251565e-16, -1.1102230246251565e-16, 0.9135454576426009, -0.40673664307580026)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1257,10 +1193,9 @@ Ok(joint_cmds)
 }
 42 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_1 = pose_0 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1332,11 +1267,10 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let target_position = pose_2.translation;
+let target_position = pose_1.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_2, jac)
+(pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1362,12 +1296,11 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let target_position = pose_3.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1393,16 +1326,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let target_position = pose_5.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1429,15 +1360,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let target_position = pose_4.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1464,17 +1394,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let target_position = pose_6.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1501,18 +1429,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let target_position = pose_7.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1539,21 +1464,18 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let target_position = pose_8.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_5.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1581,22 +1503,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let target_position = pose_9.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1624,23 +1543,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_10 = pose_9 * Translation3::new(0.1, 0.02225, -0.39246);
-let target_position = pose_10.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.022250000000000006, -0.1, -0.39246), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_10, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1718,11 +1633,10 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let target_position = pose_2.translation;
+let target_position = pose_1.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_2, jac)
+(pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1748,12 +1662,11 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let target_position = pose_3.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1779,16 +1692,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let target_position = pose_5.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1815,15 +1726,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let target_position = pose_4.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1850,17 +1760,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let target_position = pose_6.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1887,18 +1795,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let target_position = pose_7.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1925,21 +1830,18 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let target_position = pose_8.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_5.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1967,22 +1869,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let target_position = pose_9.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2010,23 +1909,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_2 = pose_1;
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_10 = pose_9 * Translation3::new(0.1, -0.02225, -0.39246);
-let target_position = pose_10.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.022250000000000006, 0.1, -0.39246), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_10, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2134,12 +2029,11 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let target_position = pose_3.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2165,16 +2059,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let target_position = pose_5.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2201,15 +2093,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let target_position = pose_4.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2236,17 +2127,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let target_position = pose_6.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2273,18 +2162,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let target_position = pose_7.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2311,21 +2197,18 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let target_position = pose_8.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_5.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2353,22 +2236,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let target_position = pose_9.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2396,23 +2276,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_10 = pose_9 * Translation3::new(-0.1, 0.02225, -0.39246);
-let target_position = pose_10.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, -0.0059999999999999915, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(-0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, 2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, 1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.022249999999999978, 0.1, -0.39246), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_10, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2520,12 +2396,11 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let target_position = pose_3.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2551,16 +2426,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let target_position = pose_5.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2587,15 +2460,14 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let target_position = pose_4.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2622,17 +2494,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let target_position = pose_6.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2659,18 +2529,15 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let target_position = pose_7.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2697,21 +2564,18 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let target_position = pose_8.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let target_position = pose_5.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2739,22 +2603,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let target_position = pose_9.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2782,23 +2643,19 @@ let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMa
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4;
-let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
-let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
-let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
-let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let pose_10 = pose_9 * Translation3::new(-0.1, -0.02225, -0.39246);
-let target_position = pose_10.translation;
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.069, 0.006000000000000009, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865475, 0.0, 0.0, -0.7071067811865476)));
+let pose_3 = pose_2 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(-0.1805, -2.7755575615628914e-17, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(2.220446049250313e-16, 0.0, 0.0, -1.0)));
+let pose_5 = pose_4 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(-1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.022249999999999978, -0.1, -0.39246), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_10, jac)
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2911,12 +2768,11 @@ let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_3 = pose_2;
-let target_position = pose_3.translation;
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2945,13 +2801,12 @@ let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_3 = pose_2;
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.055, -0.023, 0.031), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
-let target_position = pose_4.translation;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.055, -0.023, 0.031), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2980,13 +2835,12 @@ let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_3 = pose_2;
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, -0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
-let target_position = pose_4.translation;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0684, -0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -3015,13 +2869,12 @@ let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_3 = pose_2;
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.05495, 0.03, 0.03116), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
-let target_position = pose_4.translation;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.05495, 0.03, 0.03116), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -3050,13 +2903,12 @@ let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_3 = pose_2;
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, 0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
-let target_position = pose_4.translation;
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0684, 0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -3080,10 +2932,9 @@ Ok(joint_cmds)
 }
 95 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.175);
+let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.267);
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -327,6 +327,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -1250,7 +1251,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1279,7 +1280,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1309,7 +1310,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1342,7 +1343,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1376,7 +1377,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1411,7 +1412,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1446,7 +1447,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1484,7 +1485,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1524,7 +1525,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1564,7 +1565,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1616,7 +1617,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1645,7 +1646,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1675,7 +1676,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1708,7 +1709,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1742,7 +1743,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1777,7 +1778,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1812,7 +1813,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1850,7 +1851,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1890,7 +1891,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1930,7 +1931,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[3] += STEP_SIZE * dq[0];
@@ -1982,7 +1983,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2012,7 +2013,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2042,7 +2043,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2075,7 +2076,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2109,7 +2110,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2144,7 +2145,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2179,7 +2180,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2217,7 +2218,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2257,7 +2258,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2297,7 +2298,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[6] += STEP_SIZE * dq[0];
@@ -2349,7 +2350,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2379,7 +2380,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2409,7 +2410,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2442,7 +2443,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2476,7 +2477,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2511,7 +2512,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2546,7 +2547,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2584,7 +2585,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2624,7 +2625,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2664,7 +2665,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[9] += STEP_SIZE * dq[0];
@@ -2716,7 +2717,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2748,7 +2749,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2781,7 +2782,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2815,7 +2816,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2849,7 +2850,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2883,7 +2884,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -2917,7 +2918,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -335,1148 +335,976 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity();
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 2 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.144);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 3 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity();
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 4 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity();
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 5 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 6 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 7 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 8 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 9 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
 let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_4, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 10 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 11 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 12 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 13 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
 let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_4, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 14 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 15 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0;
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 16 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 17 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 18 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 19 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 20 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.04028, -0.025, -0.08051), UnitQuaternion::from_quaternion(Quaternion::new(0.8660254037844387, 0.0, 0.49999999999999994, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
 let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_4, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 21 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 22 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 23 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 24 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.00993, -0.025, -0.04096), UnitQuaternion::from_quaternion(Quaternion::new(0.9914448613738104, 0.0, 0.13052619222005157, 0.0)));
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 1.0, 0.0, 0.0));
 let pose_3 = pose_2;
 let pose_4 = pose_3 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_4, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 25 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 26 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0;
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.00421, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 27 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.4087, 0.0, 0.0205);
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 28 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.4087, 0.0, 0.0205), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, 1.0)));
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 29 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity();
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 30 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.26132, 0.0, -0.06205);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 31 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(-0.0435, 0.0, 0.144);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 32 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.25565, 0.00255, 0.07672), UnitQuaternion::from_quaternion(Quaternion::new(3.749399456654644e-33, 6.123233995736766e-17, 1.0, 6.123233995736766e-17)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 33 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 34 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 35 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
 let pose_1 = pose_0;
 let pose_2 = pose_1;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 36 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.025, 0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, -0.2534044072834003, 0.25340440728340036, 0.6601410503592005)));
 let pose_1 = pose_0;
 let pose_2 = pose_1;
 let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 37 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 38 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 39 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
 let pose_1 = pose_0;
 let pose_2 = pose_1;
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 40 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.025, -0.0923, 0.0123), UnitQuaternion::from_quaternion(Quaternion::new(0.6601410503592006, 0.2534044072834003, 0.25340440728340036, -0.6601410503592005)));
 let pose_1 = pose_0;
 let pose_2 = pose_1;
 let pose_3 = pose_2 * UnitQuaternion::from_quaternion(Quaternion::new(0.5000000000000001, -0.5, 0.4999999999999999, -0.5));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 41 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 42 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.31, 0.0, 0.1585), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
 let pose_1 = pose_0 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 43 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 44 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
@@ -1489,8 +1317,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1500,13 +1328,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 45 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_2 = pose_1;
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
@@ -1519,8 +1347,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1530,14 +1358,14 @@ iterations += 1;
 Ok(joint_cmds)
 }
 46 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_2 = pose_1;
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
@@ -1550,8 +1378,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1561,7 +1389,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 47 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1571,7 +1399,7 @@ let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuater
 let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let target_position = pose_5.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_5, jac)
@@ -1585,8 +1413,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1596,7 +1425,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 48 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1605,7 +1434,7 @@ let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, 0.006, 0.0)
 let pose_4 = pose_3 * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
@@ -1619,8 +1448,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1630,7 +1460,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 49 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1641,7 +1471,7 @@ let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let target_position = pose_6.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_6, jac)
@@ -1655,8 +1485,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1666,7 +1497,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 50 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1678,7 +1509,7 @@ let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
 let target_position = pose_7.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_7, jac)
@@ -1692,8 +1523,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1703,7 +1535,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 51 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1717,7 +1549,7 @@ let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.1805, -0.28
 let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_8.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1732,8 +1564,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1743,7 +1577,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 52 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1758,7 +1592,7 @@ let pose_8 = pose_7 * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuater
 let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let target_position = pose_9.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1773,8 +1607,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1784,7 +1620,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 53 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, 0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1800,7 +1636,7 @@ let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let pose_10 = pose_9 * Translation3::new(0.1, 0.02225, -0.39246);
 let target_position = pose_10.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1815,8 +1651,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1826,38 +1664,34 @@ iterations += 1;
 Ok(joint_cmds)
 }
 54 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 55 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1869,8 +1703,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1880,14 +1714,14 @@ iterations += 1;
 Ok(joint_cmds)
 }
 56 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_2 = pose_1;
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1899,8 +1733,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1910,15 +1744,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 57 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_2 = pose_1;
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1930,8 +1764,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1941,7 +1775,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 58 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1951,9 +1785,9 @@ let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuater
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let target_position = pose_5.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1965,8 +1799,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1976,7 +1811,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 59 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -1985,9 +1820,9 @@ let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.069, -0.006, 0.0
 let pose_4 = pose_3 * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1999,8 +1834,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2010,7 +1846,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 60 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -2021,9 +1857,9 @@ let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let target_position = pose_6.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2035,8 +1871,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2046,7 +1883,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 61 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -2058,9 +1895,9 @@ let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
 let target_position = pose_7.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2072,8 +1909,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2083,7 +1921,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 62 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -2097,10 +1935,10 @@ let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, -0.1805, -0.2
 let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_8.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_8, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2112,8 +1950,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
+joint_cmds[5] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2123,7 +1963,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 63 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -2138,10 +1978,10 @@ let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuater
 let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let target_position = pose_9.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_9, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2153,8 +1993,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
+joint_cmds[5] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2164,7 +2006,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 64 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.304, -0.109, 0.0);
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(1.0, 0.0, 0.0);
@@ -2180,10 +2022,10 @@ let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let pose_10 = pose_9 * Translation3::new(0.1, -0.02225, -0.39246);
 let target_position = pose_10.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_10, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2195,8 +2037,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[3] += STEP_SIZE * dq[0];
+joint_cmds[4] += STEP_SIZE * dq[1];
+joint_cmds[5] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2206,38 +2050,34 @@ iterations += 1;
 Ok(joint_cmds)
 }
 65 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 66 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2249,8 +2089,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2260,14 +2100,14 @@ iterations += 1;
 Ok(joint_cmds)
 }
 67 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2279,8 +2119,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2290,15 +2130,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 68 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2310,8 +2150,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2321,7 +2161,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 69 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2331,9 +2171,9 @@ let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuater
 let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let target_position = pose_5.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2345,8 +2185,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2356,7 +2197,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 70 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2365,9 +2206,9 @@ let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, 0.006, 0.0
 let pose_4 = pose_3 * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2379,8 +2220,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2390,7 +2232,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 71 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2401,9 +2243,9 @@ let axis_world_4 = pose_4.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let target_position = pose_6.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2415,8 +2257,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2426,7 +2269,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 72 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2438,9 +2281,9 @@ let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
 let target_position = pose_7.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2452,8 +2295,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2463,7 +2307,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 73 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2477,10 +2321,10 @@ let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, 0.1805, -0.2
 let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_8.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_8, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2492,8 +2336,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
+joint_cmds[8] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2503,7 +2349,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 74 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2518,10 +2364,10 @@ let pose_8 = pose_7 * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuater
 let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let target_position = pose_9.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_9, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2533,8 +2379,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
+joint_cmds[8] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2544,7 +2392,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 75 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, 0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2560,10 +2408,10 @@ let axis_world_8 = pose_8.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let pose_10 = pose_9 * Translation3::new(-0.1, 0.02225, -0.39246);
 let target_position = pose_10.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_10, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2575,8 +2423,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[6] += STEP_SIZE * dq[0];
+joint_cmds[7] += STEP_SIZE * dq[1];
+joint_cmds[8] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2586,38 +2436,34 @@ iterations += 1;
 Ok(joint_cmds)
 }
 76 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 77 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2629,8 +2475,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2640,14 +2486,14 @@ iterations += 1;
 Ok(joint_cmds)
 }
 78 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2659,8 +2505,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2670,15 +2516,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 79 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_2 = pose_1 * UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0));
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475)));
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2690,8 +2536,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2701,7 +2547,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 80 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2711,9 +2557,9 @@ let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuate
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let target_position = pose_5.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2725,8 +2571,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2736,7 +2583,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 81 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2745,9 +2592,9 @@ let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(-0.069, -0.006, 0.
 let pose_4 = pose_3 * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2759,8 +2606,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2770,7 +2618,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 82 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2781,9 +2629,9 @@ let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let target_position = pose_6.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2795,8 +2643,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2806,7 +2655,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 83 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2818,9 +2667,9 @@ let pose_5 = pose_4;
 let pose_6 = pose_5 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475));
 let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.285), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, -0.7071067811865475)));
 let target_position = pose_7.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2832,8 +2681,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2843,7 +2693,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 84 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2857,10 +2707,10 @@ let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(-0.0, -0.1805, -0.
 let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let target_position = pose_8.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_8, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2872,8 +2722,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
+joint_cmds[11] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2883,7 +2735,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 85 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2898,10 +2750,10 @@ let pose_8 = pose_7 * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuate
 let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let target_position = pose_9.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_9, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2913,8 +2765,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
+joint_cmds[11] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2924,7 +2778,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 86 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.304, -0.109, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(6.123233995736766e-17, 0.0, 0.0, -1.0)));
 let pose_1 = pose_0 * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, -s, 0.0, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(-1.0, 0.0, 0.0);
@@ -2940,10 +2794,10 @@ let axis_world_8 = pose_8.rotation * Vector3::new(-1.0, 0.0, 0.0);
 let pose_9 = pose_8 * UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.0, 0.0, 0.7071067811865475));
 let pose_10 = pose_9 * Translation3::new(-0.1, -0.02225, -0.39246);
 let target_position = pose_10.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_10, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2955,8 +2809,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[9] += STEP_SIZE * dq[0];
+joint_cmds[10] += STEP_SIZE * dq[1];
+joint_cmds[11] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2966,38 +2822,34 @@ iterations += 1;
 Ok(joint_cmds)
 }
 87 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 88 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3009,8 +2861,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3020,16 +2872,16 @@ iterations += 1;
 Ok(joint_cmds)
 }
 89 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3041,8 +2893,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3052,7 +2905,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 90 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -3060,9 +2913,9 @@ let pose_2 = pose_1 * Translation3::new(0.03, 0.0, 0.152) * { let (s, c) = (join
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2;
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3074,8 +2927,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3085,7 +2939,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 91 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -3094,9 +2948,9 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2;
 let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.055, -0.023, 0.031), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3108,8 +2962,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3119,7 +2974,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 92 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -3128,9 +2983,9 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2;
 let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, -0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3142,8 +2997,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3153,7 +3009,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 93 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -3162,9 +3018,9 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2;
 let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.05495, 0.03, 0.03116), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3176,8 +3032,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3187,7 +3044,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 94 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.023) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -3196,9 +3053,9 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2;
 let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0684, 0.023, -0.03), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999983974483, -0.5, 0.5000000016025516, -0.5)));
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 14>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -3210,8 +3067,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -3221,26 +3079,22 @@ iterations += 1;
 Ok(joint_cmds)
 }
 95 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 14>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 14]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.14253, 0.0, 0.092);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.175);
-let jac = SMatrix::<f64, 6, 14>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 14> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -98,37 +98,33 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity();
-let jac = SMatrix::<f64, 6, 7>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 2 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
@@ -141,8 +137,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -152,14 +148,14 @@ iterations += 1;
 Ok(joint_cmds)
 }
 3 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
@@ -173,8 +169,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -184,7 +181,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 4 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -193,7 +190,7 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -208,8 +205,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -219,7 +218,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 5 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -230,7 +229,7 @@ let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -246,8 +245,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -257,7 +259,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 6 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -270,7 +272,7 @@ let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_5.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 5>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -287,8 +289,12 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 5> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -298,7 +304,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 7 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 6>) {
 let pose_0 = Isometry3::identity();
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
@@ -313,7 +319,7 @@ let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_6.translation;
-let mut jac = SMatrix::<f64, 6, 7>::zeros();
+let mut jac = SMatrix::<f64, 6, 6>::zeros();
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -331,8 +337,13 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 6> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -379,7 +390,13 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -427,7 +444,13 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 7> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -80,3 +80,368 @@ let mut jacobian_flange = SMatrix::<f64, 6, 7>::zeros();
 { let lin = axis_world_7.cross(&(links[9].translation.vector - links[8].translation.vector)); let ang = axis_world_7; jacobian_flange.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 [jacobian_world, jacobian_base_link, jacobian_link1, jacobian_link2, jacobian_link3, jacobian_link4, jacobian_link5, jacobian_link6, jacobian_link7, jacobian_flange]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `Enlight-L`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 7]) -> Result<[f64; 7], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let jac = SMatrix::<f64, 6, 7>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+3 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+4 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+5 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+6 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_5.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+7 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_6.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+8 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_7 = pose_7.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_7.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7.cross(&(target_position.vector - pose_7.translation.vector)); let ang = axis_world_7; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+9 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
+let pose_0 = Isometry3::identity();
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_7 = pose_7.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_8 = pose_7 * Translation3::new(0.0, 0.0, 0.048);
+let target_position = pose_8.translation;
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7.cross(&(target_position.vector - pose_7.translation.vector)); let ang = axis_world_7; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 7> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -99,9 +99,8 @@ let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity();
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_0, jac)
+(Isometry3::identity(), jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -120,13 +119,12 @@ Ok(joint_cmds)
 }
 2 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_1.translation;
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_0.translation;
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_1, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -149,16 +147,15 @@ Ok(joint_cmds)
 }
 3 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_2.translation;
+let target_position = pose_1.translation;
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_2, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -182,19 +179,18 @@ Ok(joint_cmds)
 }
 4 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_3.translation;
+let target_position = pose_2.translation;
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -219,22 +215,21 @@ Ok(joint_cmds)
 }
 5 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_4.translation;
+let target_position = pose_3.translation;
 let mut jac = SMatrix::<f64, 6, 4>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -260,25 +255,24 @@ Ok(joint_cmds)
 }
 6 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_5.translation;
+let target_position = pose_4.translation;
 let mut jac = SMatrix::<f64, 6, 5>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -305,28 +299,27 @@ Ok(joint_cmds)
 }
 7 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 6>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_6.translation;
+let target_position = pose_5.translation;
 let mut jac = SMatrix::<f64, 6, 6>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -354,31 +347,30 @@ Ok(joint_cmds)
 }
 8 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_7 = pose_7.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_7.translation;
+let target_position = pose_6.translation;
 let mut jac = SMatrix::<f64, 6, 7>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7.cross(&(target_position.vector - pose_7.translation.vector)); let ang = axis_world_7; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -407,32 +399,31 @@ Ok(joint_cmds)
 }
 9 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 7]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
-let pose_0 = Isometry3::identity();
-let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.146) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, -0.037, 0.114), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.181, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, 0.037, 0.109), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_4 = pose_3 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_4 = pose_4.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.156, -0.037), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_5 = pose_4 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_5 = pose_5.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, -0.0261, 0.124), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, 0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let pose_6 = pose_5 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_6 = pose_6.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_7 = pose_6 * Isometry3::from_parts(Translation3::new(0.0, 0.134, -0.0261), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865476, -0.7071067811865475, 0.0, 0.0))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_7 = pose_7.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_8 = pose_7 * Translation3::new(0.0, 0.0, 0.048);
-let target_position = pose_8.translation;
+let pose_7 = pose_6 * Translation3::new(0.0, 0.0, 0.048);
+let target_position = pose_7.translation;
 let mut jac = SMatrix::<f64, 6, 7>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7.cross(&(target_position.vector - pose_7.translation.vector)); let ang = axis_world_7; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4.cross(&(target_position.vector - pose_4.translation.vector)); let ang = axis_world_4; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5.cross(&(target_position.vector - pose_5.translation.vector)); let ang = axis_world_5; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6.cross(&(target_position.vector - pose_6.translation.vector)); let ang = axis_world_6; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -90,6 +90,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -133,7 +134,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -164,7 +165,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -199,7 +200,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -238,7 +239,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -281,7 +282,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 5> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -328,7 +329,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 6> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -379,7 +380,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 7> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -432,7 +433,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 7> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];

--- a/src/generated/simple_arm_2dof.rs
+++ b/src/generated/simple_arm_2dof.rs
@@ -47,11 +47,11 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 2>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
@@ -64,8 +64,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 2> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -96,7 +96,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;

--- a/src/generated/simple_arm_2dof.rs
+++ b/src/generated/simple_arm_2dof.rs
@@ -29,3 +29,88 @@ let mut jacobian_forearm = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_1.cross(&(links[2].translation.vector - links[2].translation.vector)); let ang = axis_world_1; jacobian_forearm.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 [jacobian_base_link, jacobian_upper_arm, jacobian_forearm]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `simple_arm_2dof`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 2]) -> Result<[f64; 2], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 2> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.9) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 2> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/simple_arm_2dof.rs
+++ b/src/generated/simple_arm_2dof.rs
@@ -39,6 +39,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -62,7 +63,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -93,7 +94,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];

--- a/src/generated/simple_arm_2dof_flipped.rs
+++ b/src/generated/simple_arm_2dof_flipped.rs
@@ -39,6 +39,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -65,7 +66,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -94,7 +95,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];

--- a/src/generated/simple_arm_2dof_flipped.rs
+++ b/src/generated/simple_arm_2dof_flipped.rs
@@ -29,3 +29,88 @@ let mut jacobian_upper_arm = SMatrix::<f64, 6, 2>::zeros();
 let jacobian_base_link = SMatrix::<f64, 6, 2>::zeros();
 [jacobian_forearm, jacobian_upper_arm, jacobian_base_link]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `simple_arm_2dof_flipped`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 2]) -> Result<[f64; 2], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+0 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.9) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 2> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+1 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 2> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/simple_arm_2dof_flipped.rs
+++ b/src/generated/simple_arm_2dof_flipped.rs
@@ -68,7 +68,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -78,11 +79,11 @@ iterations += 1;
 Ok(joint_cmds)
 }
 1 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 2]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.1) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 2>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
@@ -95,8 +96,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 2> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;

--- a/src/generated/simple_arm_3dof_rrp.rs
+++ b/src/generated/simple_arm_3dof_rrp.rs
@@ -53,11 +53,11 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.05) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 3>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
@@ -70,8 +70,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 3> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -81,13 +81,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 2 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.05) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.5) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 3>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
@@ -101,8 +101,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 3> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -136,7 +137,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;

--- a/src/generated/simple_arm_3dof_rrp.rs
+++ b/src/generated/simple_arm_3dof_rrp.rs
@@ -35,3 +35,122 @@ let mut jacobian_ee_link = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jacobian_ee_link.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 [jacobian_base_link, jacobian_link1, jacobian_link2, jacobian_ee_link]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `rr_prismatic_robot`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 3]) -> Result<[f64; 3], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.05) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 3> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.05) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.5) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 3> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+3 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 3]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.05) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.0, 0.5) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Translation3::new(0.25, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_2 = pose_2.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 3> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/simple_arm_3dof_rrp.rs
+++ b/src/generated/simple_arm_3dof_rrp.rs
@@ -45,6 +45,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -68,7 +69,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -99,7 +100,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -134,7 +135,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -314,6 +314,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -820,7 +821,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -849,7 +850,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -881,7 +882,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -917,7 +918,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -957,7 +958,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1001,7 +1002,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 5> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1047,7 +1048,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 5> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1097,7 +1098,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 6> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1151,7 +1152,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 7> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1209,7 +1210,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1269,7 +1270,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1329,7 +1330,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1389,7 +1390,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1449,7 +1450,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1509,7 +1510,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1558,7 +1559,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 5> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1604,7 +1605,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 5> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1637,7 +1638,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[10] += STEP_SIZE * dq[0];
@@ -1666,7 +1667,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[11] += STEP_SIZE * dq[0];
@@ -1695,7 +1696,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -1769,7 +1770,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1832,7 +1833,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1897,7 +1898,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -1962,7 +1963,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -2026,7 +2027,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -2091,7 +2092,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -2156,7 +2157,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 9> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -2217,7 +2218,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 8> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -322,626 +322,534 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_0, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 2 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 3 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 4 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 5 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 6 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 7 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 8 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 9 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 10 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 11 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 12 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 13 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 14 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 15 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811827, -0.0264137425448753, -0.0583279884119643), UnitQuaternion::from_quaternion(Quaternion::new(-0.33944435018566044, -0.35355339059327595, -0.8535533905932726, 0.17670354420260315)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 16 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811846, 0.222413742544858, -0.0583279884119634), UnitQuaternion::from_quaternion(Quaternion::new(0.17670354420260637, -0.8535533905932764, -0.3535533905932665, -0.3394443501856592)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 17 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 18 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0212000000000001, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 19 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 20 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0211999999999999, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 21 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_2, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 22 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
 let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.00170000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_3, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 23 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 24 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
@@ -954,8 +862,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -965,13 +873,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 25 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
@@ -984,8 +892,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -995,7 +903,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 26 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1003,7 +911,7 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
 let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
@@ -1017,8 +925,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1028,7 +937,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 27 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1038,7 +947,7 @@ let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1053,8 +962,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1064,7 +975,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 28 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1076,7 +987,7 @@ let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Transla
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1092,8 +1003,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1103,7 +1017,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 29 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1117,7 +1031,7 @@ let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 5>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1134,8 +1048,12 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 5> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1145,7 +1063,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 30 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1160,7 +1078,7 @@ let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 5>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1177,8 +1095,12 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 5> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1188,7 +1110,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 31 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 6>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1206,7 +1128,7 @@ let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
 let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_9.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 6>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1224,8 +1146,13 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 6> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1235,7 +1162,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 32 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1255,7 +1182,7 @@ let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_10.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 7>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1274,8 +1201,14 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 7> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1285,7 +1218,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 33 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1307,7 +1240,7 @@ let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
 let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let target_position = pose_11.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1327,8 +1260,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1338,7 +1278,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 34 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1361,7 +1301,7 @@ let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.045199999999999
 let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
 let target_position = pose_12.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1381,8 +1321,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1392,7 +1339,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 35 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1416,7 +1363,7 @@ let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
 let pose_13 = pose_12 * UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153));
 let target_position = pose_13.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1436,8 +1383,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1447,7 +1401,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 36 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1471,7 +1425,7 @@ let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
 let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, -0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
 let target_position = pose_13.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1491,8 +1445,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1502,7 +1463,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 37 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1526,7 +1487,7 @@ let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
 let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, 0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
 let target_position = pose_13.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1546,8 +1507,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1557,7 +1525,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 38 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1580,7 +1548,7 @@ let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.045199999999999
 let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
 let target_position = pose_12.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1600,8 +1568,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1611,7 +1586,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 39 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1627,7 +1602,7 @@ let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Transla
 let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
 let pose_9 = pose_8 * Translation3::new(-0.00867000000000001, 0.0, 0.0681104510547822);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 5>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1644,8 +1619,12 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 5> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1655,7 +1634,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 40 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1671,7 +1650,7 @@ let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Transla
 let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
 let pose_9 = pose_8 * Translation3::new(0.00665000000000002, 0.0, 0.0677604510547822);
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 5>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1688,8 +1667,12 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 5> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1699,13 +1682,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 41 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.174, 0.0720000043081651), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865462, -0.7071067811865488, 0.0, 0.0))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1717,8 +1700,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[10] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1728,13 +1711,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 42 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.150688420258493, 0.087000000000001, 0.072000004308165), UnitQuaternion::from_quaternion(Quaternion::new(0.3535533905932687, -0.35355339059326996, 0.6123724356957981, -0.6123724356957959))) * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1746,8 +1729,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[11] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1757,13 +1740,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 43 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.150688420258492, 0.0869999999999999, 0.072000004308165), UnitQuaternion::from_quaternion(Quaternion::new(0.35355339059327484, -0.3535533905932761, -0.6123724356957947, 0.6123724356957925))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1775,8 +1758,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1786,33 +1769,29 @@ iterations += 1;
 Ok(joint_cmds)
 }
 44 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(0.0, 0.1768, 0.107500004308165);
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
 Ok(joint_cmds)
 }
 45 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1836,7 +1815,7 @@ let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
 let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
 let pose_13 = pose_12;
 let target_position = pose_13.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1856,8 +1835,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1867,7 +1853,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 46 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1893,7 +1879,7 @@ let pose_13 = pose_12;
 let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_14.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1914,8 +1900,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[8] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1925,7 +1919,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 47 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -1952,7 +1946,7 @@ let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.03779950412552
 let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
 let target_position = pose_15.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -1973,8 +1967,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[8] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -1984,7 +1986,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 48 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -2012,7 +2014,7 @@ let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
 let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520835, 0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.263911150603878, 0.21755156406573753, 0.597718009837648, 0.7250899270264412)));
 let target_position = pose_16.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -2033,8 +2035,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[8] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2044,7 +2054,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 49 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -2070,7 +2080,7 @@ let pose_13 = pose_12;
 let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
 let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let target_position = pose_14.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -2079,7 +2089,7 @@ let mut jac = SMatrix::<f64, 6, 13>::zeros();
 { let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_14, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2091,8 +2101,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[9] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2102,7 +2120,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 50 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -2129,7 +2147,7 @@ let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) 
 let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
 let target_position = pose_15.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -2138,7 +2156,7 @@ let mut jac = SMatrix::<f64, 6, 13>::zeros();
 { let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_15, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2150,8 +2168,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[9] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2161,7 +2187,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 51 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -2189,7 +2215,7 @@ let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
 let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
 let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520833, -0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7250899270264408, 0.5977180098376478, 0.21755156406573833, 0.263911150603879)));
 let target_position = pose_16.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 9>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -2198,7 +2224,7 @@ let mut jac = SMatrix::<f64, 6, 13>::zeros();
 { let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_16, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -2210,8 +2236,16 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 9> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
+joint_cmds[9] += STEP_SIZE * dq[8];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2221,7 +2255,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 52 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
 let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
@@ -2246,7 +2280,7 @@ let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
 let pose_13 = pose_12;
 let pose_14 = pose_13 * Translation3::new(0.23496234568483, 0.0, 0.0);
 let target_position = pose_14.translation;
-let mut jac = SMatrix::<f64, 6, 13>::zeros();
+let mut jac = SMatrix::<f64, 6, 8>::zeros();
 { let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -2266,8 +2300,15 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 8> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
+joint_cmds[4] += STEP_SIZE * dq[4];
+joint_cmds[5] += STEP_SIZE * dq[5];
+joint_cmds[6] += STEP_SIZE * dq[6];
+joint_cmds[7] += STEP_SIZE * dq[7];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -2277,26 +2318,22 @@ iterations += 1;
 Ok(joint_cmds)
 }
 53 => {
-let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
 let pose_1 = pose_0;
-let jac = SMatrix::<f64, 6, 13>::zeros();
+let jac = SMatrix::<f64, 6, 0>::zeros();
 (pose_1, jac)
 };
-let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
 let mut iterations: usize = 0;
 while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
-let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 13> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
-let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+let (pose, _new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
-jac = new_jac;
+_jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -304,3 +304,2010 @@ let mut jacobian_grasp_center_link = SMatrix::<f64, 6, 13>::zeros();
 let jacobian_laser = SMatrix::<f64, 6, 13>::zeros();
 [jacobian_base_footprint, jacobian_base_link, jacobian_line_sensor_5_link, jacobian_line_sensor_5_optical_link, jacobian_line_sensor_4_link, jacobian_line_sensor_4_optical_link, jacobian_line_sensor_3_link, jacobian_line_sensor_3_optical_link, jacobian_line_sensor_2_link, jacobian_line_sensor_2_optical_link, jacobian_line_sensor_1_link, jacobian_line_sensor_1_optical_link, jacobian_line_sensor_0_link, jacobian_line_sensor_0_optical_link, jacobian_head_link, jacobian_lidar_right_link, jacobian_lidar_left_link, jacobian_camera_right_link, jacobian_camera_right_optical_link, jacobian_camera_left_link, jacobian_camera_left_optical_link, jacobian_camera_center_link, jacobian_camera_center_optical_link, jacobian_mast_link, jacobian_lift_link, jacobian_arm_l0_link, jacobian_arm_l1_link, jacobian_arm_l2_link, jacobian_arm_l3_link, jacobian_arm_l4_link, jacobian_wrist_link, jacobian_wrist_yaw_link, jacobian_wrist_pitch_link, jacobian_wrist_roll_link, jacobian_gripper_camera_link, jacobian_gripper_stereo_camera_color_optical_frame, jacobian_gripper_right_camera_color_optical_frame, jacobian_gripper_left_camera_color_optical_frame, jacobian_tool_attachment_site_link, jacobian_wrist_aruco_link, jacobian_wrist_reflector_link, jacobian_wheel_2_link, jacobian_wheel_1_link, jacobian_wheel_0_link, jacobian_docking_contact_link, jacobian_quick_connect_interface_link, jacobian_gripper_finger_right_link, jacobian_gripper_fingertip_right_link, jacobian_aruco_fingertip_right_link, jacobian_gripper_finger_left_link, jacobian_gripper_fingertip_left_link, jacobian_aruco_fingertip_left_link, jacobian_grasp_center_link, jacobian_laser]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `stretch4`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 13]) -> Result<[f64; 13], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+3 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+4 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+5 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+6 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+7 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+8 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+9 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+10 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+11 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+12 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+13 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+14 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+15 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811827, -0.0264137425448753, -0.0583279884119643), UnitQuaternion::from_quaternion(Quaternion::new(-0.33944435018566044, -0.35355339059327595, -0.8535533905932726, 0.17670354420260315)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+16 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811846, 0.222413742544858, -0.0583279884119634), UnitQuaternion::from_quaternion(Quaternion::new(0.17670354420260637, -0.8535533905932764, -0.3535533905932665, -0.3394443501856592)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+17 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+18 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0212000000000001, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+19 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+20 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0211999999999999, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+21 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+22 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
+let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.00170000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+23 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+24 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+25 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+26 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+27 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+28 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+29 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+30 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+31 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_9.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+32 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_10.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+33 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_11.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+34 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
+let target_position = pose_12.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_12, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+35 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
+let pose_13 = pose_12 * UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153));
+let target_position = pose_13.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+36 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, -0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
+let target_position = pose_13.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+37 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, 0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
+let target_position = pose_13.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+38 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let target_position = pose_12.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_12, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+39 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * Translation3::new(-0.00867000000000001, 0.0, 0.0681104510547822);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+40 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * Translation3::new(0.00665000000000002, 0.0, 0.0677604510547822);
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+41 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0, -0.174, 0.0720000043081651), UnitQuaternion::from_quaternion(Quaternion::new(0.7071067811865462, -0.7071067811865488, 0.0, 0.0))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+42 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.150688420258493, 0.087000000000001, 0.072000004308165), UnitQuaternion::from_quaternion(Quaternion::new(0.3535533905932687, -0.35355339059326996, 0.6123724356957981, -0.6123724356957959))) * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+43 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.150688420258492, 0.0869999999999999, 0.072000004308165), UnitQuaternion::from_quaternion(Quaternion::new(0.35355339059327484, -0.3535533905932761, -0.6123724356957947, 0.6123724356957925))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+44 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(0.0, 0.1768, 0.107500004308165);
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+45 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let target_position = pose_13.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+46 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_14.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_14, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+47 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
+let target_position = pose_15.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_15, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+48 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
+let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520835, 0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.263911150603878, 0.21755156406573753, 0.597718009837648, 0.7250899270264412)));
+let target_position = pose_16.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_16, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+49 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_14.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_14, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+50 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
+let target_position = pose_15.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_15, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+51 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
+let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520833, -0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7250899270264408, 0.5977180098376478, 0.21755156406573833, 0.263911150603879)));
+let target_position = pose_16.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_16, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+52 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
+let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_13 = pose_12;
+let pose_14 = pose_13 * Translation3::new(0.23496234568483, 0.0, 0.0);
+let target_position = pose_14.translation;
+let mut jac = SMatrix::<f64, 6, 13>::zeros();
+{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_14, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+53 => {
+let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 13>) {
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
+let pose_1 = pose_0;
+let jac = SMatrix::<f64, 6, 13>::zeros();
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 13> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -344,10 +344,9 @@ Ok(joint_cmds)
 }
 2 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -366,11 +365,9 @@ Ok(joint_cmds)
 }
 3 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0613832011662534, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911043, -0.11247552717193304, 0.19481332766988357, 0.48718503239261407)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.06266847665246124, 0.18054498559500573, 0.07944765235504582), UnitQuaternion::from_quaternion(Quaternion::new(0.5118627031709491, -0.8191515580127682, 0.21949099844822154, -0.13715319795027095)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -389,10 +386,9 @@ Ok(joint_cmds)
 }
 4 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -411,11 +407,9 @@ Ok(joint_cmds)
 }
 5 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0613832011662525, 0.178318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.4871850323926196, -0.1948133276698832, 0.11247552717193458, 0.843829228791101)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0626684766524603, 0.18054498559500573, 0.07944765235504583), UnitQuaternion::from_quaternion(Quaternion::new(0.5118627031709504, -0.8191515580127704, -0.21949099844821437, 0.13715319795026448)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -434,10 +428,9 @@ Ok(joint_cmds)
 }
 6 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -456,11 +449,9 @@ Ok(joint_cmds)
 }
 7 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.185120231404985, -0.036, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(1.5741382716533137e-15, 0.22495105434386758, 3.6341845535812523e-16, -0.9743700647852346)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.18769078237740058, -0.036000000000000004, 0.07944765235504583), UnitQuaternion::from_quaternion(Quaternion::new(-0.3747095052206829, 0.5996605595645514, 0.5996605595645521, -0.3747095052206819)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -479,10 +470,9 @@ Ok(joint_cmds)
 }
 8 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -501,11 +491,9 @@ Ok(joint_cmds)
 }
 9 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.123737030238733, -0.14231882315117, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.48718503239261535, 0.19481332766988338, 0.11247552717193335, -0.8438292287911036)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.12502230572494083, -0.1445449855950047, 0.07944765235504583), UnitQuaternion::from_quaternion(Quaternion::new(-0.1371531979502702, 0.2194909984482203, 0.8191515580127685, -0.5118627031709492)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -524,10 +512,9 @@ Ok(joint_cmds)
 }
 10 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -546,11 +533,9 @@ Ok(joint_cmds)
 }
 11 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.123737030238732, -0.142318823151171, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.8438292287911018, 0.11247552717193401, 0.194813327669883, -0.4871850323926183)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.1250223057249398, -0.14454498559500573, 0.07944765235504583), UnitQuaternion::from_quaternion(Quaternion::new(0.13715319795026534, -0.21949099844821562, 0.8191515580127697, -0.5118627031709504)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -569,10 +554,9 @@ Ok(joint_cmds)
 }
 12 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0807013938348626), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -591,11 +575,9 @@ Ok(joint_cmds)
 }
 13 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.185120231404985, -0.0360000000000004, 0.0527013981430276), UnitQuaternion::from_quaternion(Quaternion::new(0.9743700647852346, 0.0, 0.22495105434386758, 0.0)));
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.00286000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.1876907823774006, -0.0360000000000004, 0.07944765235504582), UnitQuaternion::from_quaternion(Quaternion::new(0.3747095052206813, -0.5996605595645511, 0.5996605595645523, -0.37470950522068347)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -614,10 +596,9 @@ Ok(joint_cmds)
 }
 14 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.587000000000005);
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -636,11 +617,9 @@ Ok(joint_cmds)
 }
 15 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811827, -0.0264137425448753, -0.0583279884119643), UnitQuaternion::from_quaternion(Quaternion::new(-0.33944435018566044, -0.35355339059327595, -0.8535533905932726, 0.17670354420260315)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0387442118118268, -0.1244137425448751, 1.5286720115880408), UnitQuaternion::from_quaternion(Quaternion::new(-0.33944435018566044, -0.35355339059327595, -0.8535533905932726, 0.17670354420260315)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -659,11 +638,9 @@ Ok(joint_cmds)
 }
 16 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.131744211811846, 0.222413742544858, -0.0583279884119634), UnitQuaternion::from_quaternion(Quaternion::new(0.17670354420260637, -0.8535533905932764, -0.3535533905932665, -0.3394443501856592)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.03874421181184581, 0.1244137425448582, 1.5286720115880417), UnitQuaternion::from_quaternion(Quaternion::new(0.17670354420260637, -0.8535533905932764, -0.3535533905932665, -0.3394443501856592)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -682,11 +659,9 @@ Ok(joint_cmds)
 }
 17 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.07884060278789382, -0.0749999999999966, 1.5712433012927576), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -705,12 +680,9 @@ Ok(joint_cmds)
 }
 18 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787894, 0.0230000000000032, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, 0.6484593973531617, 0.2819581706288638, -0.28195817062886486)));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0212000000000001, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.09329896802121881, -0.0749999999999966, 1.555738602818431), UnitQuaternion::from_quaternion(Quaternion::new(0.3665012267242946, 1.0269562977782698e-15, 0.9304175679820255, 2.3314683517128287e-15)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -729,11 +701,9 @@ Ok(joint_cmds)
 }
 19 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.07884060278789481, 0.07500000000000019, 1.5712433012927576), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -752,12 +722,9 @@ Ok(joint_cmds)
 }
 20 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.171840602787895, 0.173, -0.0157566987072475), UnitQuaternion::from_quaternion(Quaternion::new(0.6484593973531594, -0.6484593973531617, 0.2819581706288638, 0.28195817062886486)));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.0211999999999999, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.09329896802121967, 0.07500000000000019, 1.5557386028184312), UnitQuaternion::from_quaternion(Quaternion::new(-2.3037127760972e-15, -0.9304175679820242, -1.0547118733938987e-15, -0.36650122672429786)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -776,11 +743,9 @@ Ok(joint_cmds)
 }
 21 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0842456034024118, 6.106226635438361e-16, 1.5630930902061078), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_2, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -799,12 +764,9 @@ Ok(joint_cmds)
 }
 22 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 1.55900000430817);
-let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.177245603402412, 0.0980000000000004, -0.0239069097938973), UnitQuaternion::from_quaternion(Quaternion::new(0.6743797232066263, -0.6743797232066288, 0.2126311099715944, 0.21263110997159518)));
-let pose_3 = pose_2 * Isometry3::from_parts(Translation3::new(0.00170000000000003, 0.0, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.49999999999999817, -0.5, 0.5000000000000018, -0.5)));
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.08563816187770311, 6.106226635438361e-16, 1.5621180102643109), UnitQuaternion::from_quaternion(Quaternion::new(-2.42861286636753e-15, -0.8870108331782214, -7.771561172376096e-16, -0.4617486132350344)));
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_3, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -823,10 +785,9 @@ Ok(joint_cmds)
 }
 23 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -845,13 +806,12 @@ Ok(joint_cmds)
 }
 24 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_2, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -874,14 +834,13 @@ Ok(joint_cmds)
 }
 25 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
 let mut jac = SMatrix::<f64, 6, 1>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_3, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -904,17 +863,16 @@ Ok(joint_cmds)
 }
 26 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
-let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
 let mut jac = SMatrix::<f64, 6, 2>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_4, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -938,20 +896,19 @@ Ok(joint_cmds)
 }
 27 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
-let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
 let mut jac = SMatrix::<f64, 6, 3>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_5, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -976,23 +933,22 @@ Ok(joint_cmds)
 }
 28 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
-let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
 let mut jac = SMatrix::<f64, 6, 4>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_6, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_5, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1018,26 +974,25 @@ Ok(joint_cmds)
 }
 29 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
 let mut jac = SMatrix::<f64, 6, 5>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_7, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_6, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1064,27 +1019,26 @@ Ok(joint_cmds)
 }
 30 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
 let mut jac = SMatrix::<f64, 6, 5>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_8, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1111,31 +1065,30 @@ Ok(joint_cmds)
 }
 31 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 6>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_9.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_8.translation;
 let mut jac = SMatrix::<f64, 6, 6>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_8, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1163,34 +1116,33 @@ Ok(joint_cmds)
 }
 32 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 7>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let target_position = pose_10.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_9.translation;
 let mut jac = SMatrix::<f64, 6, 7>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_10, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_9, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1219,37 +1171,36 @@ Ok(joint_cmds)
 }
 33 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let target_position = pose_11.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let target_position = pose_10.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_11, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_10, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1279,38 +1230,37 @@ Ok(joint_cmds)
 }
 34 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
-let target_position = pose_12.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_12, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1340,39 +1290,37 @@ Ok(joint_cmds)
 }
 35 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
-let pose_13 = pose_12 * UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153));
-let target_position = pose_13.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999999999982, -0.49999999999999983, 0.5000000000000016, -0.5000000000000002)));
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_13, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1402,39 +1350,37 @@ Ok(joint_cmds)
 }
 36 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
-let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, -0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
-let target_position = pose_13.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Isometry3::from_parts(Translation3::new(0.0192000000000001, -0.01, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999999999982, -0.49999999999999983, 0.5000000000000016, -0.5000000000000002)));
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_13, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1464,39 +1410,37 @@ Ok(joint_cmds)
 }
 37 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.0, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.9996573249755573, 0.0, 0.026176948307873107, 0.0)));
-let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.0, 0.01, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.5129171366417135, -0.48674018833384197, 0.48674018833384375, -0.5129171366417153)));
-let target_position = pose_13.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Isometry3::from_parts(Translation3::new(0.0192000000000001, 0.01, 0.057), UnitQuaternion::from_quaternion(Quaternion::new(0.4999999999999982, -0.49999999999999983, 0.5000000000000016, -0.5000000000000002)));
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_13, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1526,38 +1470,37 @@ Ok(joint_cmds)
 }
 38 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let target_position = pose_12.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_12, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1587,28 +1530,26 @@ Ok(joint_cmds)
 }
 39 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * Translation3::new(-0.00867000000000001, 0.0, 0.0681104510547822);
+let pose_7 = pose_6 * Translation3::new(0.28473, 0.0, 0.03139045105478219);
 let mut jac = SMatrix::<f64, 6, 5>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1635,28 +1576,26 @@ Ok(joint_cmds)
 }
 40 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 5>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * Translation3::new(0.00665000000000002, 0.0, 0.0677604510547822);
+let pose_7 = pose_6 * Translation3::new(0.30005000000000004, 0.0, 0.031040451054782203);
 let mut jac = SMatrix::<f64, 6, 5>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_9, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_7, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1770,10 +1709,9 @@ Ok(joint_cmds)
 }
 44 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(0.0, 0.1768, 0.107500004308165);
+let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.1768, 0.1355);
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1792,39 +1730,37 @@ Ok(joint_cmds)
 }
 45 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let target_position = pose_13.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_13, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1854,42 +1790,40 @@ Ok(joint_cmds)
 }
 46 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_14.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_12.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_14, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_12, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1920,43 +1854,41 @@ Ok(joint_cmds)
 }
 47 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
-let target_position = pose_15.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
+let target_position = pose_13.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_15, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -1987,44 +1919,41 @@ Ok(joint_cmds)
 }
 48 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164326, -0.0221679999883885, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.2902312652061124e-15, 0.798635510047297, -0.6018150231520427, -9.722589954653042e-16)));
-let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520835, 0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.263911150603878, 0.21755156406573753, 0.597718009837648, 0.7250899270264412)));
-let target_position = pose_16.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Isometry3::from_parts(Translation3::new(0.0377995041255281, -0.0221213818384166, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(1.6155445744325867e-15, 1.0, 0.0, 0.0))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.15898650355967442, -0.026754994620999287, 1.0354252757116205e-16), UnitQuaternion::from_quaternion(Quaternion::new(0.18597127359961052, -0.22560119485103267, -0.7379082589116738, 0.608284627216131)));
+let target_position = pose_13.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_16, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2055,42 +1984,40 @@ Ok(joint_cmds)
 }
 49 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let target_position = pose_14.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let target_position = pose_12.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_14, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_12, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2121,43 +2048,41 @@ Ok(joint_cmds)
 }
 50 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
-let target_position = pose_15.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
+let target_position = pose_13.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_15, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2188,44 +2113,41 @@ Ok(joint_cmds)
 }
 51 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 9>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_14 = pose_14.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_15 = pose_14 * Isometry3::from_parts(Translation3::new(0.191008332164325, -0.0221679999883927, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7986355100472909, 0.0, 0.0, -0.6018150231520507)));
-let pose_16 = pose_15 * Isometry3::from_parts(Translation3::new(-0.00441710992520833, -0.0320457043432331, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7250899270264408, 0.5977180098376478, 0.21755156406573833, 0.263911150603879)));
-let target_position = pose_16.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.0186, 0.0, 0.0);
+let pose_12 = pose_11 * Translation3::new(0.0378, 0.022121, 0.0) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_12 = pose_12.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_13 = pose_12 * Isometry3::from_parts(Translation3::new(0.1589865035596733, -0.026754994621002864, 0.0), UnitQuaternion::from_quaternion(Quaternion::new(0.7379082589116722, 0.6082846272161286, -0.18597127359961485, -0.22560119485103997)));
+let target_position = pose_13.translation;
 let mut jac = SMatrix::<f64, 6, 9>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_14.cross(&(target_position.vector - pose_14.translation.vector)); let ang = axis_world_14; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_16, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_12.cross(&(target_position.vector - pose_12.translation.vector)); let ang = axis_world_12; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_13, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2256,40 +2178,37 @@ Ok(joint_cmds)
 }
 52 => {
 let compute_pose_and_jacobian = |joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 8>) {
-let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0 * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.00400000430816486);
-let pose_2 = pose_1 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
-let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_3 = pose_2 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
-let pose_4 = pose_3 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let pose_0 = Isometry3::identity() * Translation3::new(-0.0930000000000002, -0.0979999999999998, 0.03199999999999986);
+let pose_1 = pose_0 * Translation3::new(0.0, -0.00140000000000005, 0.241) * Translation3::from(Vector3::new(0.0, 0.0, 1.0) * joint_cmds[0]);
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_2 = pose_1 * Translation3::new(0.01675, 0.0994000000000002, -0.0128595489452177);
+let pose_3 = pose_2 * Translation3::new(-0.01375, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[1]);
+let axis_world_3 = pose_3.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
 let axis_world_4 = pose_4.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_5 = pose_4 * Translation3::new(-0.0135000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[2]);
+let pose_5 = pose_4 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
 let axis_world_5 = pose_5.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_6 = pose_5 * Translation3::new(-0.0135, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[3]);
+let pose_6 = pose_5 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
 let axis_world_6 = pose_6.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_7 = pose_6 * Translation3::new(-0.0055000000000001, 0.0, 0.0) * Translation3::from(Vector3::new(1.0, 0.0, 0.0) * joint_cmds[4]);
-let axis_world_7 = pose_7.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_8 = pose_7 * Translation3::new(0.2934, 0.0, -0.03672);
-let pose_9 = pose_8 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
-let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 0.0, 1.0);
-let pose_10 = pose_9 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
-let axis_world_10 = pose_10.rotation * Vector3::new(0.0, 1.0, 0.0);
-let pose_11 = pose_10 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
-let axis_world_11 = pose_11.rotation * Vector3::new(1.0, 0.0, 0.0);
-let pose_12 = pose_11 * Translation3::new(0.0186, 0.0, 0.0);
-let pose_13 = pose_12;
-let pose_14 = pose_13 * Translation3::new(0.23496234568483, 0.0, 0.0);
-let target_position = pose_14.translation;
+let pose_7 = pose_6 * Translation3::new(0.2934, 0.0, -0.03672);
+let pose_8 = pose_7 * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, 0.0, s)) };
+let axis_world_8 = pose_8.rotation * Vector3::new(0.0, 0.0, 1.0);
+let pose_9 = pose_8 * Translation3::new(0.0, -0.04222, -0.0452) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_9 = pose_9.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_10 = pose_9 * Translation3::new(0.0422200000000001, -0.0451999999999999, 0.0) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, s, 0.0, 0.0)) };
+let axis_world_10 = pose_10.rotation * Vector3::new(1.0, 0.0, 0.0);
+let pose_11 = pose_10 * Translation3::new(0.25356234568483, 0.0, 0.0);
+let target_position = pose_11.translation;
 let mut jac = SMatrix::<f64, 6, 8>::zeros();
-{ let lin = axis_world_2; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_7; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_11.cross(&(target_position.vector - pose_11.translation.vector)); let ang = axis_world_11; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-(pose_14, jac)
+{ let lin = axis_world_1; let ang = Vector3::zeros(); jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3; let ang = Vector3::zeros(); jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_4; let ang = Vector3::zeros(); jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_5; let ang = Vector3::zeros(); jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_6; let ang = Vector3::zeros(); jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_8.cross(&(target_position.vector - pose_8.translation.vector)); let ang = axis_world_8; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_9.cross(&(target_position.vector - pose_9.translation.vector)); let ang = axis_world_9; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_10.cross(&(target_position.vector - pose_10.translation.vector)); let ang = axis_world_10; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_11, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);
@@ -2320,9 +2239,8 @@ Ok(joint_cmds)
 53 => {
 let compute_pose_and_jacobian = |_joint_cmds: &[f64; 13]| -> (Isometry3<f64>, SMatrix<f64, 6, 0>) {
 let pose_0 = Isometry3::identity() * Translation3::new(0.0, 0.0, 0.027999995691835);
-let pose_1 = pose_0;
 let jac = SMatrix::<f64, 6, 0>::zeros();
-(pose_1, jac)
+(pose_0, jac)
 };
 let (mut current_pose, mut _jac) = compute_pose_and_jacobian(&joint_cmds);
 let mut error = compute_error(&current_pose);

--- a/src/generated/wuji_hand_v1_right.rs
+++ b/src/generated/wuji_hand_v1_right.rs
@@ -170,6 +170,7 @@ const ERROR_TOLERANCE: f64 = 1e-5;
 const DAMPING_FACTOR: f64 = 1e-4;
 const STEP_SIZE: f64 = 1.0;
 const MAX_ITERATIONS: usize = 1000;
+let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
 let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
 let error_position = target_pose.translation.vector - current_pose.translation.vector;
 let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
@@ -193,7 +194,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -224,7 +225,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -259,7 +260,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -298,7 +299,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -339,7 +340,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[0] += STEP_SIZE * dq[0];
@@ -370,7 +371,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[4] += STEP_SIZE * dq[0];
@@ -401,7 +402,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[4] += STEP_SIZE * dq[0];
@@ -436,7 +437,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[4] += STEP_SIZE * dq[0];
@@ -475,7 +476,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[4] += STEP_SIZE * dq[0];
@@ -516,7 +517,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[4] += STEP_SIZE * dq[0];
@@ -547,7 +548,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[8] += STEP_SIZE * dq[0];
@@ -578,7 +579,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[8] += STEP_SIZE * dq[0];
@@ -613,7 +614,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[8] += STEP_SIZE * dq[0];
@@ -652,7 +653,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[8] += STEP_SIZE * dq[0];
@@ -693,7 +694,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[8] += STEP_SIZE * dq[0];
@@ -724,7 +725,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -755,7 +756,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -790,7 +791,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -829,7 +830,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -870,7 +871,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[12] += STEP_SIZE * dq[0];
@@ -901,7 +902,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 1> = jac.transpose() * x;
 joint_cmds[16] += STEP_SIZE * dq[0];
@@ -932,7 +933,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 2> = jac.transpose() * x;
 joint_cmds[16] += STEP_SIZE * dq[0];
@@ -967,7 +968,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 3> = jac.transpose() * x;
 joint_cmds[16] += STEP_SIZE * dq[0];
@@ -1006,7 +1007,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[16] += STEP_SIZE * dq[0];
@@ -1047,7 +1048,7 @@ while error.norm() > ERROR_TOLERANCE {
 if iterations >= MAX_ITERATIONS {
 return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
 }
-let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let jjt_damped = jac * jac.transpose() + damping_matrix;
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
 let dq: SVector<f64, 4> = jac.transpose() * x;
 joint_cmds[16] += STEP_SIZE * dq[0];

--- a/src/generated/wuji_hand_v1_right.rs
+++ b/src/generated/wuji_hand_v1_right.rs
@@ -160,3 +160,869 @@ let mut jacobian_right_finger5_tip_link = SMatrix::<f64, 6, 20>::zeros();
 { let lin = axis_world_23.cross(&(links[25].translation.vector - links[24].translation.vector)); let ang = axis_world_23; jacobian_right_finger5_tip_link.set_column(19, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 [jacobian_right_palm_link, jacobian_right_finger1_link1, jacobian_right_finger1_link2, jacobian_right_finger1_link3, jacobian_right_finger1_link4, jacobian_right_finger1_tip_link, jacobian_right_finger2_link1, jacobian_right_finger2_link2, jacobian_right_finger2_link3, jacobian_right_finger2_link4, jacobian_right_finger2_tip_link, jacobian_right_finger3_link1, jacobian_right_finger3_link2, jacobian_right_finger3_link3, jacobian_right_finger3_link4, jacobian_right_finger3_tip_link, jacobian_right_finger4_link1, jacobian_right_finger4_link2, jacobian_right_finger4_link3, jacobian_right_finger4_link4, jacobian_right_finger4_tip_link, jacobian_right_finger5_link1, jacobian_right_finger5_link2, jacobian_right_finger5_link3, jacobian_right_finger5_link4, jacobian_right_finger5_tip_link]
 }
+use nalgebra::{SVector, Matrix6};
+use crate::error::KinematicsError;
+/// Computes inverse kinematics for the robot described by `wujihand-right`.
+#[allow(non_snake_case)]
+#[rustfmt::skip]
+pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 20]) -> Result<[f64; 20], KinematicsError> {
+const ERROR_TOLERANCE: f64 = 1e-5;
+const DAMPING_FACTOR: f64 = 1e-4;
+const STEP_SIZE: f64 = 1.0;
+const MAX_ITERATIONS: usize = 1000;
+let compute_error = |current_pose: &Isometry3<f64>| -> Vector6<f64> {
+let error_position = target_pose.translation.vector - current_pose.translation.vector;
+let error_rotation = (target_pose.rotation * current_pose.rotation.inverse()).scaled_axis();
+Vector6::new(error_position.x, error_position.y, error_position.z, error_rotation.x, error_rotation.y, error_rotation.z)
+};
+let mut joint_cmds = *initial_joint_cmds;
+match target_link_idx {
+1 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+2 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+3 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.000266705, 0.0009915016, 0.03466562), UnitQuaternion::from_quaternion(Quaternion::new(0.8157388773627973, 0.01500362433027275, 0.021238187340727802, 0.5778355428790437))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+4 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.000266705, 0.0009915016, 0.03466562), UnitQuaternion::from_quaternion(Quaternion::new(0.8157388773627973, 0.01500362433027275, 0.021238187340727802, 0.5778355428790437))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, 0.0002, 0.0295) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+5 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.000266705, 0.0009915016, 0.03466562), UnitQuaternion::from_quaternion(Quaternion::new(0.8157388773627973, 0.01500362433027275, 0.021238187340727802, 0.5778355428790437))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, 0.0002, 0.0295) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.00105, -0.0002, 0.0313);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+6 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+7 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+8 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004750282, 0.04361766), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+9 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004750282, 0.04361766), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+10 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004750282, 0.04361766), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.00105, 0.0002, 0.0267);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+11 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+12 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+13 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.00475, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+14 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.00475, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+15 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.00475, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.001049087, 0.0002010395, 0.0267);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+16 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+17 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+18 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[14] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+19 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[14] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[15] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(15, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+20 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[14] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[15] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.00105961, 0.0001904508, 0.0267);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(15, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+21 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_0.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_0, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+22 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_1.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_1, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+23 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[18] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_2.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_2, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+24 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[18] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[19] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let target_position = pose_3.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(19, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_3, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+25 => {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[18] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[19] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
+let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
+let pose_4 = pose_3 * Translation3::new(-0.001044639, 0.0002113095, 0.0267);
+let target_position = pose_4.translation;
+let mut jac = SMatrix::<f64, 6, 20>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(19, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+(pose_4, jac)
+};
+let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
+let mut error = compute_error(&current_pose);
+let mut iterations: usize = 0;
+while error.norm() > ERROR_TOLERANCE {
+if iterations >= MAX_ITERATIONS {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.norm() });
+}
+let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
+let dq: SVector<f64, 20> = jac.transpose() * x;
+for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
+current_pose = pose;
+jac = new_jac;
+error = compute_error(&current_pose);
+iterations += 1;
+}
+Ok(joint_cmds)
+}
+_ => {
+let error = compute_error(&Isometry3::identity());
+if error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations: 0, final_error: error.norm() });
+}
+Ok(joint_cmds)
+}
+}
+}

--- a/src/generated/wuji_hand_v1_right.rs
+++ b/src/generated/wuji_hand_v1_right.rs
@@ -178,11 +178,11 @@ Vector6::new(error_position.x, error_position.y, error_position.z, error_rotatio
 let mut joint_cmds = *initial_joint_cmds;
 match target_link_idx {
 1 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
@@ -195,8 +195,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -206,13 +206,13 @@ iterations += 1;
 Ok(joint_cmds)
 }
 2 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
@@ -226,8 +226,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -237,7 +238,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 3 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -245,7 +246,7 @@ let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(-0.000266705, 0.0009915016, 0.03466562), UnitQuaternion::from_quaternion(Quaternion::new(0.8157388773627973, 0.01500362433027275, 0.021238187340727802, 0.5778355428790437))) * { let (s, c) = (joint_cmds[2] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -260,8 +261,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -271,7 +274,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 4 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -281,7 +284,7 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2 * Translation3::new(0.0, 0.0002, 0.0295) * { let (s, c) = (joint_cmds[3] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -297,8 +300,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -308,7 +314,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 5 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(0.0084399, 0.020587, 0.028893), UnitQuaternion::from_quaternion(Quaternion::new(0.6822193668878683, -0.6176690399171142, 0.08050471975634982, -0.3828585674474818))) * { let (s, c) = (joint_cmds[0] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(-0.0047549, -0.0058191, 0.014132), UnitQuaternion::from_quaternion(Quaternion::new(0.7262524781813893, 0.29085087339109844, -0.08559118145800193, -0.6169580674889091))) * { let (s, c) = (joint_cmds[1] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -319,7 +325,7 @@ let pose_3 = pose_2 * Translation3::new(0.0, 0.0002, 0.0295) * { let (s, c) = (j
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_4 = pose_3 * Translation3::new(-0.00105, -0.0002, 0.0313);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
 { let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 { let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
@@ -335,8 +341,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[0] += STEP_SIZE * dq[0];
+joint_cmds[1] += STEP_SIZE * dq[1];
+joint_cmds[2] += STEP_SIZE * dq[2];
+joint_cmds[3] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -346,12 +355,12 @@ iterations += 1;
 Ok(joint_cmds)
 }
 6 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -363,8 +372,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[4] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -374,15 +383,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 7 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -394,8 +403,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[4] += STEP_SIZE * dq[0];
+joint_cmds[5] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -405,7 +415,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 8 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -413,10 +423,10 @@ let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004750282, 0.04361766), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[6] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -428,8 +438,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[4] += STEP_SIZE * dq[0];
+joint_cmds[5] += STEP_SIZE * dq[1];
+joint_cmds[6] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -439,7 +451,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 9 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -449,11 +461,11 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[7] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -465,8 +477,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[4] += STEP_SIZE * dq[0];
+joint_cmds[5] += STEP_SIZE * dq[1];
+joint_cmds[6] += STEP_SIZE * dq[2];
+joint_cmds[7] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -476,7 +491,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 10 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0058701, 0.029434, 0.091917), UnitQuaternion::from_quaternion(Quaternion::new(0.9916887635847301, -0.058829485633527225, -0.029275462547150216, -0.11061390099139398))) * { let (s, c) = (joint_cmds[4] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[5] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -487,11 +502,11 @@ let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_4 = pose_3 * Translation3::new(-0.00105, 0.0002, 0.0267);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(4, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(5, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(6, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(7, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -503,8 +518,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[4] += STEP_SIZE * dq[0];
+joint_cmds[5] += STEP_SIZE * dq[1];
+joint_cmds[6] += STEP_SIZE * dq[2];
+joint_cmds[7] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -514,12 +532,12 @@ iterations += 1;
 Ok(joint_cmds)
 }
 11 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -531,8 +549,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[8] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -542,15 +560,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 12 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -562,8 +580,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[8] += STEP_SIZE * dq[0];
+joint_cmds[9] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -573,7 +592,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 13 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -581,10 +600,10 @@ let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.00475, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[10] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -596,8 +615,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[8] += STEP_SIZE * dq[0];
+joint_cmds[9] += STEP_SIZE * dq[1];
+joint_cmds[10] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -607,7 +628,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 14 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -617,11 +638,11 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[11] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -633,8 +654,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[8] += STEP_SIZE * dq[0];
+joint_cmds[9] += STEP_SIZE * dq[1];
+joint_cmds[10] += STEP_SIZE * dq[2];
+joint_cmds[11] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -644,7 +668,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 15 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.01046, 0.0074615, 0.089544), UnitQuaternion::from_quaternion(Quaternion::new(0.9990481890991502, -1.2684824867247146e-5, -0.04361916183339305, 0.00029054733912970787))) * { let (s, c) = (joint_cmds[8] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.0022, 0.0, 0.004000006), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[9] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -655,11 +679,11 @@ let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_4 = pose_3 * Translation3::new(-0.001049087, 0.0002010395, 0.0267);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(8, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(9, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(10, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(11, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -671,8 +695,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[8] += STEP_SIZE * dq[0];
+joint_cmds[9] += STEP_SIZE * dq[1];
+joint_cmds[10] += STEP_SIZE * dq[2];
+joint_cmds[11] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -682,12 +709,12 @@ iterations += 1;
 Ok(joint_cmds)
 }
 16 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -699,8 +726,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -710,15 +737,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 17 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -730,8 +757,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -741,7 +769,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 18 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -749,10 +777,10 @@ let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[14] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -764,8 +792,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
+joint_cmds[14] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -775,7 +805,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 19 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -785,11 +815,11 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[15] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(15, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -801,8 +831,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
+joint_cmds[14] += STEP_SIZE * dq[2];
+joint_cmds[15] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -812,7 +845,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 20 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.0076649, -0.013712, 0.084429), UnitQuaternion::from_quaternion(Quaternion::new(0.9977885672599305, 0.04610193435442398, -0.04058837269304493, 0.025400210555943416))) * { let (s, c) = (joint_cmds[12] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[13] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -823,11 +856,11 @@ let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_4 = pose_3 * Translation3::new(-0.00105961, 0.0001904508, 0.0267);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(12, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(13, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(14, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(15, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -839,8 +872,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[12] += STEP_SIZE * dq[0];
+joint_cmds[13] += STEP_SIZE * dq[1];
+joint_cmds[14] += STEP_SIZE * dq[2];
+joint_cmds[15] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -850,12 +886,12 @@ iterations += 1;
 Ok(joint_cmds)
 }
 21 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 1>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_0.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 1>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_0, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -867,8 +903,8 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 1> = jac.transpose() * x;
+joint_cmds[16] += STEP_SIZE * dq[0];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -878,15 +914,15 @@ iterations += 1;
 Ok(joint_cmds)
 }
 22 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 2>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_1.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 2>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_1, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -898,8 +934,9 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 2> = jac.transpose() * x;
+joint_cmds[16] += STEP_SIZE * dq[0];
+joint_cmds[17] += STEP_SIZE * dq[1];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -909,7 +946,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 23 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 3>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -917,10 +954,10 @@ let axis_world_1 = pose_1.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_2 = pose_1 * Isometry3::from_parts(Translation3::new(0.0, 0.004749999, 0.04361769), UnitQuaternion::from_quaternion(Quaternion::new(0.7070117844838688, 0.0, 0.0, -0.707201765128549))) * { let (s, c) = (joint_cmds[18] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_2.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 3>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_2, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -932,8 +969,10 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 3> = jac.transpose() * x;
+joint_cmds[16] += STEP_SIZE * dq[0];
+joint_cmds[17] += STEP_SIZE * dq[1];
+joint_cmds[18] += STEP_SIZE * dq[2];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -943,7 +982,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 24 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -953,11 +992,11 @@ let axis_world_2 = pose_2.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (joint_cmds[19] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let target_position = pose_3.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(19, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_3, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -969,8 +1008,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[16] += STEP_SIZE * dq[0];
+joint_cmds[17] += STEP_SIZE * dq[1];
+joint_cmds[18] += STEP_SIZE * dq[2];
+joint_cmds[19] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;
@@ -980,7 +1022,7 @@ iterations += 1;
 Ok(joint_cmds)
 }
 25 => {
-let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 20>) {
+let compute_pose_and_jacobian = |joint_cmds: &[f64; 20]| -> (Isometry3<f64>, SMatrix<f64, 6, 4>) {
 let pose_0 = Isometry3::identity() * Isometry3::from_parts(Translation3::new(-0.002268651, -0.03400111, 0.07428134), UnitQuaternion::from_quaternion(Quaternion::new(0.9908692876130022, 0.09931734008761313, -0.03832545015380128, 0.08273621150217035))) * { let (s, c) = (joint_cmds[16] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
 let axis_world_0 = pose_0.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_1 = pose_0 * Isometry3::from_parts(Translation3::new(0.002200001, 0.0, 0.004000005), UnitQuaternion::from_quaternion(Quaternion::new(0.7071068967259818, 0.0, 0.0, 0.7071066656470943))) * { let (s, c) = (joint_cmds[17] * 0.5).sin_cos(); UnitQuaternion::new_unchecked(Quaternion::new(c, 0.0, s, 0.0)) };
@@ -991,11 +1033,11 @@ let pose_3 = pose_2 * Translation3::new(0.0, -0.0002, 0.0295) * { let (s, c) = (
 let axis_world_3 = pose_3.rotation * Vector3::new(0.0, 1.0, 0.0);
 let pose_4 = pose_3 * Translation3::new(-0.001044639, 0.0002113095, 0.0267);
 let target_position = pose_4.translation;
-let mut jac = SMatrix::<f64, 6, 20>::zeros();
-{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(16, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(17, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(18, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
-{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(19, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+let mut jac = SMatrix::<f64, 6, 4>::zeros();
+{ let lin = axis_world_0.cross(&(target_position.vector - pose_0.translation.vector)); let ang = axis_world_0; jac.set_column(0, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_1.cross(&(target_position.vector - pose_1.translation.vector)); let ang = axis_world_1; jac.set_column(1, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_2.cross(&(target_position.vector - pose_2.translation.vector)); let ang = axis_world_2; jac.set_column(2, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
+{ let lin = axis_world_3.cross(&(target_position.vector - pose_3.translation.vector)); let ang = axis_world_3; jac.set_column(3, &Vector6::new(lin.x, lin.y, lin.z, ang.x, ang.y, ang.z)); }
 (pose_4, jac)
 };
 let (mut current_pose, mut jac) = compute_pose_and_jacobian(&joint_cmds);
@@ -1007,8 +1049,11 @@ return Err(KinematicsError::IkDidNotConverge { iterations, final_error: error.no
 }
 let jjt_damped = jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
 let x = jjt_damped.cholesky().expect("J*J^T + damping*I is always positive definite for damping > 0").solve(&error);
-let dq: SVector<f64, 20> = jac.transpose() * x;
-for (q, dq_i) in joint_cmds.iter_mut().zip(dq.iter()) { *q += STEP_SIZE * dq_i; }
+let dq: SVector<f64, 4> = jac.transpose() * x;
+joint_cmds[16] += STEP_SIZE * dq[0];
+joint_cmds[17] += STEP_SIZE * dq[1];
+joint_cmds[18] += STEP_SIZE * dq[2];
+joint_cmds[19] += STEP_SIZE * dq[3];
 let (pose, new_jac) = compute_pose_and_jacobian(&joint_cmds);
 current_pose = pose;
 jac = new_jac;

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -296,6 +296,7 @@ impl GalawModel {
 
         let mut joint_cmds_candidate = initial_joint_cmds.to_vec();
         let mut chain_poses: Vec<Isometry3<f64>> = Vec::with_capacity(chain.len());
+        let damping_matrix = DAMPING_FACTOR * Matrix6::identity();
         let mut jac: Matrix6xX<f64> = Matrix6xX::zeros(self.num_actuated_joints);
         let mut dq: DVector<f64> = DVector::zeros(self.num_actuated_joints);
 
@@ -318,7 +319,7 @@ impl GalawModel {
                 .into());
             }
 
-            let jjt_damped = &jac * jac.transpose() + DAMPING_FACTOR * Matrix6::identity();
+            let jjt_damped = &jac * jac.transpose() + damping_matrix;
             let x = jjt_damped
                 .cholesky()
                 .expect("J*J^T + damping*I is always positive definite for damping > 0")

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -1,11 +1,12 @@
 /// Tests the correctness of the implemented inverse kinematics function
 /// with Rust's k library
 // Third-party
+use nalgebra::Isometry3;
 use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 // Custom
-use galaw::types::GalawModel;
+use galaw::{error::KinematicsError, types::GalawModel};
 
 mod common;
 use common::{RNG_SEED, TestResult, random_joint_cmds, setup_kinematic_models, zero_joint_cmds};
@@ -126,6 +127,63 @@ fn check_ik_for_urdf(urdf_path: &str) -> TestResult {
 
     Ok(())
 }
+
+/// Compares a codegen'd `compute_ik` against the dynamic `GalawModel::compute_ik`.
+fn check_generated_matches_runtime<const N: usize>(
+    urdf_path: &str,
+    generated_compute_ik: impl Fn(
+        usize,
+        &Isometry3<f64>,
+        &[f64; N],
+    ) -> Result<[f64; N], KinematicsError>,
+) -> TestResult {
+    let (galaw_model, _) = setup_kinematic_models(urdf_path);
+
+    let candidates = candidate_target_links(&galaw_model);
+    assert!(
+        !candidates.is_empty(),
+        "no valid IK target links found for {urdf_path}"
+    );
+    let mut rng = ChaCha8Rng::seed_from_u64(RNG_SEED);
+
+    for _ in 0..NUM_POSES {
+        let target_link_idx = candidates[rng.random_range(0..candidates.len())];
+        let target_joint_cmd: Vec<f64> = random_joint_cmds(&galaw_model, &mut rng);
+        let init_joint_cmd: Vec<f64> =
+            perturbed_joint_cmds(&galaw_model, &target_joint_cmd, &mut rng, MAX_PERTUBATION);
+
+        eprintln!(
+            "[input] target_link_idx = {target_link_idx}, target_joint_cmd = {:?}",
+            target_joint_cmd
+        );
+
+        let target_pose = galaw_model.compute_fk(&target_joint_cmd)?[target_link_idx];
+
+        let init_joint_cmd_arr: [f64; N] = init_joint_cmd.try_into().unwrap();
+        let solved_joint_cmds =
+            generated_compute_ik(target_link_idx, &target_pose, &init_joint_cmd_arr)?;
+        let solved_pose = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
+
+        assert_galaw_transform_close(&target_pose, &solved_pose, &TEST_TOLERANCE);
+    }
+
+    Ok(())
+}
+
+/// Generates one `#[test]` per robot with codegen'd IK
+macro_rules! ik_codegen_correctness_test {
+    ($module:ident, $path:expr, $compute_fk:path) => {
+        mod $module {
+            use super::*;
+
+            #[test]
+            fn matches_runtime() -> TestResult {
+                check_generated_matches_runtime($path, galaw::generated::$module::compute_ik)
+            }
+        }
+    };
+}
+galaw::for_each_generated_robot!(ik_codegen_correctness_test);
 
 /// Generates one `#[test]` per URDF.
 macro_rules! ik_correctness_tests {


### PR DESCRIPTION
# Features
- Code generated IK. Result is 2.09x faster than galaw-runtime, 11.0x faster than k.
- Created respective tests, benchmark, and plotting. 

# Results
| Robot | joints | runtime | generated | k | generated vs runtime | generated vs k |
|---|---|---|---|---|---|---|
| Enlight-L | 9 | 6.41 µs | 3.42 µs | 161.18 µs | 1.87× | 47.1× |
| anymal-D | 95 | 5.74 µs | 2.95 µs | 14.40 µs | 1.94× | 4.9× |
| stretch4 | 53 | 5.31 µs | 2.42 µs | 50.50 µs | 2.20× | 20.9× |
| wujihand-right | 25 | 5.91 µs | 2.46 µs | 7.55 µs | 2.40× | 3.1× |

* galaw-generated vs galaw-runtime: ~2.09× faster, averaged across the four robots
* galaw-generated vs k: ~11.0× faster, averaged across the four robots

<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/041750af-0348-43f6-8c43-9c60d9f25f6f" />
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/6a4e6a7a-f3e8-4c44-a9ea-e033c635d6c9" />

