### PR TITLE
feat: ik joint clamping

### DIFF
--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -331,7 +331,13 @@ fn generate_ik_fn_code(
     let n = galaw_model.num_actuated_joints;
 
     codegen_output.push(format!(
-        "/// Computes inverse kinematics for the robot described by `{}`.",
+        "/// Computes inverse kinematics for the robot described by `{}`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.",
         galaw_model.name
     ));
     codegen_output.push("#[allow(non_snake_case)]".to_string());
@@ -636,6 +642,23 @@ fn generate_ik_fn_code(
         codegen_output.push(format!("{} = {};", jac_binding, new_jac_binding));
         codegen_output.push("error = compute_error(&current_pose);".to_string());
         codegen_output.push("iterations += 1;".to_string());
+        codegen_output.push("}".to_string());
+        // Clamp each actuated chain joint to its limits, then re-verify FK.
+        for &joint_idx in &chain {
+            let joint = &galaw_model.joints[joint_idx];
+            if let Some(cmd_idx) = joint.cmd_idx {
+                let lo = joint.limit_lower.unwrap_or(f64::NEG_INFINITY);
+                let hi = joint.limit_upper.unwrap_or(f64::INFINITY);
+                // Use {:?} so integer-valued limits emit `0.0` not `0` (valid f64 literal).
+                codegen_output.push(format!(
+                    "joint_cmds[{cmd_idx}] = joint_cmds[{cmd_idx}].clamp({lo:?}_f64, {hi:?}_f64);"
+                ));
+            }
+        }
+        codegen_output.push("let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);".to_string());
+        codegen_output.push("let clamped_error = compute_error(&clamped_pose);".to_string());
+        codegen_output.push("if clamped_error.norm() > ERROR_TOLERANCE {".to_string());
+        codegen_output.push("return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });".to_string());
         codegen_output.push("}".to_string());
         codegen_output.push("Ok(joint_cmds)".to_string());
         codegen_output.push("}".to_string()); // closes this match arm

--- a/src/bin/codegen_kinematics.rs
+++ b/src/bin/codegen_kinematics.rs
@@ -655,7 +655,8 @@ fn generate_ik_fn_code(
                 ));
             }
         }
-        codegen_output.push("let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);".to_string());
+        codegen_output
+            .push("let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);".to_string());
         codegen_output.push("let clamped_error = compute_error(&clamped_pose);".to_string());
         codegen_output.push("if clamped_error.norm() > ERROR_TOLERANCE {".to_string());
         codegen_output.push("return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });".to_string());

--- a/src/generated/anymal_d.rs
+++ b/src/generated/anymal_d.rs
@@ -320,6 +320,12 @@ let jacobian_inspection_payload_camera_default = SMatrix::<f64, 6, 14>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `anymal-D`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 14]) -> Result<[f64; 14], KinematicsError> {
@@ -353,6 +359,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -374,6 +385,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 3 => {
@@ -394,6 +410,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 4 => {
@@ -413,6 +434,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -435,6 +461,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 6 => {
@@ -455,6 +486,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -477,6 +513,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 8 => {
@@ -497,6 +538,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -519,6 +565,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 10 => {
@@ -539,6 +590,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -561,6 +617,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 12 => {
@@ -581,6 +642,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -603,6 +669,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 14 => {
@@ -623,6 +694,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -645,6 +721,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 16 => {
@@ -665,6 +746,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -687,6 +773,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 18 => {
@@ -707,6 +798,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -729,6 +825,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 20 => {
@@ -749,6 +850,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -771,6 +877,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 22 => {
@@ -791,6 +902,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -813,6 +929,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 24 => {
@@ -833,6 +954,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -855,6 +981,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 26 => {
@@ -875,6 +1006,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -897,6 +1033,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 28 => {
@@ -918,6 +1059,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 29 => {
@@ -937,6 +1083,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -959,6 +1110,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 31 => {
@@ -979,6 +1135,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1001,6 +1162,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 33 => {
@@ -1021,6 +1187,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1043,6 +1214,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 35 => {
@@ -1063,6 +1239,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1085,6 +1266,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 37 => {
@@ -1105,6 +1291,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1127,6 +1318,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 39 => {
@@ -1147,6 +1343,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1169,6 +1370,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 41 => {
@@ -1189,6 +1395,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1211,6 +1422,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 43 => {
@@ -1231,6 +1447,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1261,6 +1482,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 45 => {
@@ -1289,6 +1516,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1319,6 +1552,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1354,6 +1593,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 48 => {
@@ -1387,6 +1633,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1423,6 +1676,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 50 => {
@@ -1457,6 +1717,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1496,6 +1763,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1537,6 +1812,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 53 => {
@@ -1577,6 +1860,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 54 => {
@@ -1597,6 +1888,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1627,6 +1923,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 56 => {
@@ -1655,6 +1957,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1685,6 +1993,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1720,6 +2034,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 59 => {
@@ -1753,6 +2074,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1789,6 +2117,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 61 => {
@@ -1823,6 +2158,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1862,6 +2204,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1903,6 +2253,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 64 => {
@@ -1943,6 +2301,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[3] = joint_cmds[3].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 65 => {
@@ -1963,6 +2329,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1992,6 +2363,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2023,6 +2400,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 68 => {
@@ -2052,6 +2435,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2087,6 +2476,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 70 => {
@@ -2120,6 +2516,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2156,6 +2559,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 72 => {
@@ -2190,6 +2600,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2229,6 +2646,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[8] = joint_cmds[8].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2270,6 +2695,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[8] = joint_cmds[8].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 75 => {
@@ -2310,6 +2743,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[6] = joint_cmds[6].clamp(-0.7853985_f64, 0.6108655_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[8] = joint_cmds[8].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 76 => {
@@ -2330,6 +2771,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2359,6 +2805,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2390,6 +2842,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 79 => {
@@ -2419,6 +2877,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2454,6 +2918,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 81 => {
@@ -2487,6 +2958,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2523,6 +3001,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 83 => {
@@ -2557,6 +3042,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2596,6 +3088,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[11] = joint_cmds[11].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2637,6 +3137,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[11] = joint_cmds[11].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 86 => {
@@ -2677,6 +3185,14 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[9] = joint_cmds[9].clamp(-0.6108655_f64, 0.7853985_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+joint_cmds[11] = joint_cmds[11].clamp(-9.42477796076938_f64, 9.42477796076938_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 87 => {
@@ -2697,6 +3213,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2726,6 +3247,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2760,6 +3287,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 90 => {
@@ -2792,6 +3326,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2827,6 +3368,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 92 => {
@@ -2860,6 +3408,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2895,6 +3450,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 94 => {
@@ -2929,6 +3491,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-2.6_f64, 2.6_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-1.570796_f64, 1.570796_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 95 => {
@@ -2949,6 +3518,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/enlight_l.rs
+++ b/src/generated/enlight_l.rs
@@ -83,6 +83,12 @@ let mut jacobian_flange = SMatrix::<f64, 6, 7>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `Enlight-L`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 7]) -> Result<[f64; 7], KinematicsError> {
@@ -116,6 +122,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -143,6 +154,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -175,6 +192,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -211,6 +235,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -251,6 +283,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-2.1817_f64, 2.1817_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -295,6 +336,16 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-6.3705_f64, 6.3705_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -343,6 +394,17 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-2.1817_f64, 2.1817_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -396,6 +458,18 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-6.3705_f64, 6.3705_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 9 => {
@@ -448,6 +522,18 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[4] = joint_cmds[4].clamp(-6.3705_f64, 6.3705_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-2.1817_f64, 2.1817_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-6.3705_f64, 6.3705_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/simple_arm_2dof.rs
+++ b/src/generated/simple_arm_2dof.rs
@@ -32,6 +32,12 @@ let mut jacobian_forearm = SMatrix::<f64, 6, 2>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `simple_arm_2dof`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 2]) -> Result<[f64; 2], KinematicsError> {
@@ -73,6 +79,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-1.57_f64, 1.57_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -104,6 +116,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-1.57_f64, 1.57_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-1.57_f64, 1.57_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/simple_arm_2dof_flipped.rs
+++ b/src/generated/simple_arm_2dof_flipped.rs
@@ -32,6 +32,12 @@ let jacobian_base_link = SMatrix::<f64, 6, 2>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `simple_arm_2dof_flipped`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 2]) -> Result<[f64; 2], KinematicsError> {
@@ -77,6 +83,13 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-1.57_f64, 1.57_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-1.57_f64, 1.57_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 1 => {
@@ -104,6 +117,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-1.57_f64, 1.57_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/simple_arm_3dof_rrp.rs
+++ b/src/generated/simple_arm_3dof_rrp.rs
@@ -38,6 +38,12 @@ let mut jacobian_ee_link = SMatrix::<f64, 6, 3>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `rr_prismatic_robot`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 3]) -> Result<[f64; 3], KinematicsError> {
@@ -79,6 +85,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(-3.14_f64, 3.14_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -110,6 +122,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-3.14_f64, 3.14_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-1.57_f64, 1.57_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -146,6 +165,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(-3.14_f64, 3.14_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-1.57_f64, 1.57_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.3_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/stretch4.rs
+++ b/src/generated/stretch4.rs
@@ -307,6 +307,12 @@ let jacobian_laser = SMatrix::<f64, 6, 13>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `stretch4`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 13]) -> Result<[f64; 13], KinematicsError> {
@@ -341,6 +347,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -361,6 +372,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -383,6 +399,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 4 => {
@@ -403,6 +424,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -425,6 +451,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 6 => {
@@ -445,6 +476,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -467,6 +503,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 8 => {
@@ -487,6 +528,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -509,6 +555,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 10 => {
@@ -529,6 +580,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -551,6 +607,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 12 => {
@@ -571,6 +632,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -593,6 +659,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 14 => {
@@ -613,6 +684,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -635,6 +711,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 16 => {
@@ -655,6 +736,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -677,6 +763,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 18 => {
@@ -697,6 +788,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -719,6 +815,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 20 => {
@@ -739,6 +840,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -761,6 +867,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 22 => {
@@ -782,6 +893,11 @@ _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 23 => {
@@ -802,6 +918,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -831,6 +952,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 25 => {
@@ -859,6 +986,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -892,6 +1025,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -929,6 +1069,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -970,6 +1118,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1016,6 +1173,16 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 30 => {
@@ -1061,6 +1228,16 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1112,6 +1289,17 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1167,6 +1355,18 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1226,6 +1426,19 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1287,6 +1500,19 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 35 => {
@@ -1346,6 +1572,19 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1407,6 +1646,19 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 37 => {
@@ -1466,6 +1718,19 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1527,6 +1792,19 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 39 => {
@@ -1572,6 +1850,16 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1619,6 +1907,16 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 41 => {
@@ -1647,6 +1945,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[10] = joint_cmds[10].clamp(-6.283185307179586_f64, 6.283185307179586_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1677,6 +1981,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[11] = joint_cmds[11].clamp(-6.283185307179586_f64, 6.283185307179586_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 43 => {
@@ -1706,6 +2016,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-6.283185307179586_f64, 6.283185307179586_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 44 => {
@@ -1726,6 +2042,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1786,6 +2107,19 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1850,6 +2184,20 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[8] = joint_cmds[8].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1916,6 +2264,20 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[8] = joint_cmds[8].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 48 => {
@@ -1981,6 +2343,20 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[8] = joint_cmds[8].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 49 => {
@@ -2044,6 +2420,20 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[9] = joint_cmds[9].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -2110,6 +2500,20 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[9] = joint_cmds[9].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 51 => {
@@ -2175,6 +2579,20 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+joint_cmds[9] = joint_cmds[9].clamp(0.0_f64, 0.5_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 52 => {
@@ -2235,6 +2653,19 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0_f64, 1.2_f64);
+joint_cmds[1] = joint_cmds[1].clamp(0.0_f64, 0.13_f64);
+joint_cmds[2] = joint_cmds[2].clamp(0.0_f64, 0.13_f64);
+joint_cmds[3] = joint_cmds[3].clamp(0.0_f64, 0.13_f64);
+joint_cmds[4] = joint_cmds[4].clamp(0.0_f64, 0.13_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-1.135_f64, 4.276_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-4.276_f64, 1.135_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 53 => {
@@ -2255,6 +2686,11 @@ current_pose = pose;
 _jac = _new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/generated/wuji_hand_v1_right.rs
+++ b/src/generated/wuji_hand_v1_right.rs
@@ -163,6 +163,12 @@ let mut jacobian_right_finger5_tip_link = SMatrix::<f64, 6, 20>::zeros();
 use nalgebra::{SVector, Matrix6};
 use crate::error::KinematicsError;
 /// Computes inverse kinematics for the robot described by `wujihand-right`.
+///
+/// The returned commands are clamped into each joint's limits. If the clamped
+/// configuration no longer reaches `target_pose` within tolerance, returns
+/// [`KinematicsError::IkDidNotConverge`]. This is a deliberately simple baseline
+/// with no null-space handling, so it can fail on redundant chains where a
+/// limits-aware solver would succeed.
 #[allow(non_snake_case)]
 #[rustfmt::skip]
 pub fn compute_ik(target_link_idx: usize, target_pose: &Isometry3<f64>, initial_joint_cmds: &[f64; 20]) -> Result<[f64; 20], KinematicsError> {
@@ -204,6 +210,12 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0475_f64, 1.6033_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 2 => {
@@ -235,6 +247,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0475_f64, 1.6033_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-0.1387_f64, 0.9324_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -271,6 +290,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0475_f64, 1.6033_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-0.1387_f64, 0.9324_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-0.4642_f64, 1.5623_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -311,6 +338,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[0] = joint_cmds[0].clamp(0.0475_f64, 1.6033_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-0.1387_f64, 0.9324_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-0.4642_f64, 1.5623_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-0.4699_f64, 1.5568_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -353,6 +389,15 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[0] = joint_cmds[0].clamp(0.0475_f64, 1.6033_f64);
+joint_cmds[1] = joint_cmds[1].clamp(-0.1387_f64, 0.9324_f64);
+joint_cmds[2] = joint_cmds[2].clamp(-0.4642_f64, 1.5623_f64);
+joint_cmds[3] = joint_cmds[3].clamp(-0.4699_f64, 1.5568_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 6 => {
@@ -380,6 +425,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[4] = joint_cmds[4].clamp(-0.1585_f64, 1.5604_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -412,6 +463,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[4] = joint_cmds[4].clamp(-0.1585_f64, 1.5604_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-0.37_f64, 0.37_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -448,6 +506,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[4] = joint_cmds[4].clamp(-0.1585_f64, 1.5604_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-0.4777_f64, 1.5485_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -488,6 +554,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[4] = joint_cmds[4].clamp(-0.1585_f64, 1.5604_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-0.4777_f64, 1.5485_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-0.4683_f64, 1.5753_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -530,6 +605,15 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[4] = joint_cmds[4].clamp(-0.1585_f64, 1.5604_f64);
+joint_cmds[5] = joint_cmds[5].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[6] = joint_cmds[6].clamp(-0.4777_f64, 1.5485_f64);
+joint_cmds[7] = joint_cmds[7].clamp(-0.4683_f64, 1.5753_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 11 => {
@@ -557,6 +641,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[8] = joint_cmds[8].clamp(-0.1644_f64, 1.5516_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -589,6 +679,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[8] = joint_cmds[8].clamp(-0.1644_f64, 1.5516_f64);
+joint_cmds[9] = joint_cmds[9].clamp(-0.37_f64, 0.37_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -625,6 +722,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[8] = joint_cmds[8].clamp(-0.1644_f64, 1.5516_f64);
+joint_cmds[9] = joint_cmds[9].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-0.4739_f64, 1.5512_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -665,6 +770,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[8] = joint_cmds[8].clamp(-0.1644_f64, 1.5516_f64);
+joint_cmds[9] = joint_cmds[9].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-0.4739_f64, 1.5512_f64);
+joint_cmds[11] = joint_cmds[11].clamp(-0.4684_f64, 1.5745_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -707,6 +821,15 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[8] = joint_cmds[8].clamp(-0.1644_f64, 1.5516_f64);
+joint_cmds[9] = joint_cmds[9].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[10] = joint_cmds[10].clamp(-0.4739_f64, 1.5512_f64);
+joint_cmds[11] = joint_cmds[11].clamp(-0.4684_f64, 1.5745_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 16 => {
@@ -734,6 +857,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-0.1554_f64, 1.5585_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -766,6 +895,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-0.1554_f64, 1.5585_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-0.37_f64, 0.37_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -802,6 +938,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-0.1554_f64, 1.5585_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[14] = joint_cmds[14].clamp(-0.4765_f64, 1.5487_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -842,6 +986,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[12] = joint_cmds[12].clamp(-0.1554_f64, 1.5585_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[14] = joint_cmds[14].clamp(-0.4765_f64, 1.5487_f64);
+joint_cmds[15] = joint_cmds[15].clamp(-0.4777_f64, 1.5634_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -884,6 +1037,15 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[12] = joint_cmds[12].clamp(-0.1554_f64, 1.5585_f64);
+joint_cmds[13] = joint_cmds[13].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[14] = joint_cmds[14].clamp(-0.4765_f64, 1.5487_f64);
+joint_cmds[15] = joint_cmds[15].clamp(-0.4777_f64, 1.5634_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 21 => {
@@ -911,6 +1073,12 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[16] = joint_cmds[16].clamp(-0.1626_f64, 1.5585_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -943,6 +1111,13 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[16] = joint_cmds[16].clamp(-0.1626_f64, 1.5585_f64);
+joint_cmds[17] = joint_cmds[17].clamp(-0.37_f64, 0.37_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -979,6 +1154,14 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[16] = joint_cmds[16].clamp(-0.1626_f64, 1.5585_f64);
+joint_cmds[17] = joint_cmds[17].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[18] = joint_cmds[18].clamp(-0.4768_f64, 1.549_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }
@@ -1020,6 +1203,15 @@ jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
 }
+joint_cmds[16] = joint_cmds[16].clamp(-0.1626_f64, 1.5585_f64);
+joint_cmds[17] = joint_cmds[17].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[18] = joint_cmds[18].clamp(-0.4768_f64, 1.549_f64);
+joint_cmds[19] = joint_cmds[19].clamp(-0.4683_f64, 1.5735_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
+}
 Ok(joint_cmds)
 }
 25 => {
@@ -1060,6 +1252,15 @@ current_pose = pose;
 jac = new_jac;
 error = compute_error(&current_pose);
 iterations += 1;
+}
+joint_cmds[16] = joint_cmds[16].clamp(-0.1626_f64, 1.5585_f64);
+joint_cmds[17] = joint_cmds[17].clamp(-0.37_f64, 0.37_f64);
+joint_cmds[18] = joint_cmds[18].clamp(-0.4768_f64, 1.549_f64);
+joint_cmds[19] = joint_cmds[19].clamp(-0.4683_f64, 1.5735_f64);
+let (clamped_pose, _) = compute_pose_and_jacobian(&joint_cmds);
+let clamped_error = compute_error(&clamped_pose);
+if clamped_error.norm() > ERROR_TOLERANCE {
+return Err(KinematicsError::IkDidNotConverge { iterations, final_error: clamped_error.norm() });
 }
 Ok(joint_cmds)
 }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -357,16 +357,16 @@ impl GalawModel {
         }
 
         let clamped_pose = self.compute_restricted_pose_and_fill_jacobian(
-            &chain, 
-            &joint_cmds_candidate, 
-            &mut chain_poses, 
+            &chain,
+            &joint_cmds_candidate,
+            &mut chain_poses,
             &mut jac,
         );
         let clamped_error = compute_error(&clamped_pose)?;
         if clamped_error.norm() > ERROR_TOLERANCE {
-            return Err(KinematicsError::IkDidNotConverge { 
-                iterations, 
-                final_error: clamped_error.norm(), 
+            return Err(KinematicsError::IkDidNotConverge {
+                iterations,
+                final_error: clamped_error.norm(),
             }
             .into());
         }

--- a/src/kinematics.rs
+++ b/src/kinematics.rs
@@ -279,6 +279,17 @@ impl GalawModel {
         }
         chain.reverse();
 
+        // Extracting joint limits
+        // Defaulting to 0.0 for safety
+        let mut joint_lower = vec![0.0; self.num_actuated_joints];
+        let mut joint_upper = vec![0.0; self.num_actuated_joints];
+        for joint in &self.joints {
+            if let Some(cmd_idx) = joint.cmd_idx {
+                joint_lower[cmd_idx] = joint.limit_lower.unwrap_or(0.0);
+                joint_upper[cmd_idx] = joint.limit_upper.unwrap_or(0.0);
+            }
+        }
+
         // Helper to compute pose error
         let compute_error = |current_pose: &Isometry3<f64>| -> Result<Vector6<f64>, GalawError> {
             let error_position = target_pose.translation.vector - current_pose.translation.vector;
@@ -337,6 +348,27 @@ impl GalawModel {
             );
             error = compute_error(&current_pose)?;
             iterations += 1;
+        }
+
+        // Clamped converged solution to joint limits
+        // No null-space steering
+        for (i, cmd) in joint_cmds_candidate.iter_mut().enumerate() {
+            *cmd = cmd.clamp(joint_lower[i], joint_upper[i]);
+        }
+
+        let clamped_pose = self.compute_restricted_pose_and_fill_jacobian(
+            &chain, 
+            &joint_cmds_candidate, 
+            &mut chain_poses, 
+            &mut jac,
+        );
+        let clamped_error = compute_error(&clamped_pose)?;
+        if clamped_error.norm() > ERROR_TOLERANCE {
+            return Err(KinematicsError::IkDidNotConverge { 
+                iterations, 
+                final_error: clamped_error.norm(), 
+            }
+            .into());
         }
 
         Ok(joint_cmds_candidate)

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -81,18 +81,17 @@ fn assert_galaw_ik_correctness(
 
     let target_link_pose = galaw_model.compute_fk(target_joint_cmd)?[target_link_idx];
 
-    let solved_joint_cmds = match galaw_model.compute_ik(
-        target_link_idx, 
-        &target_link_pose, 
-        init_joint_cmd,
-    ) {
-        Ok(cmds) => cmds, 
-        Err(galaw::error::GalawError::Kinematics(KinematicsError::IkDidNotConverge { .. })) => {
-            eprintln!("[skip] IK did not converge after clamping");
-            return Ok(());
-        }
-        Err(e) => return Err(e.into()),
-    };
+    let solved_joint_cmds =
+        match galaw_model.compute_ik(target_link_idx, &target_link_pose, init_joint_cmd) {
+            Ok(cmds) => cmds,
+            Err(galaw::error::GalawError::Kinematics(KinematicsError::IkDidNotConverge {
+                ..
+            })) => {
+                eprintln!("[skip] IK did not converge after clamping");
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
 
     // Joint commands must be within joint limits
     for (joint, &cmd) in galaw_model
@@ -110,8 +109,7 @@ fn assert_galaw_ik_correctness(
         }
     }
 
-    let solved_link_poses =
-        galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
+    let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
     assert_galaw_transform_close(&target_link_pose, &solved_link_poses, &TEST_TOLERANCE);
 
     Ok(())
@@ -187,14 +185,15 @@ fn check_generated_matches_runtime<const N: usize>(
         let target_pose = galaw_model.compute_fk(&target_joint_cmd)?[target_link_idx];
 
         let init_joint_cmd_arr: [f64; N] = init_joint_cmd.try_into().unwrap();
-        let solved_joint_cmds = match generated_compute_ik(target_link_idx, &target_pose, &init_joint_cmd_arr) {
-            Ok(cmds) => cmds,
-            Err(KinematicsError::IkDidNotConverge { .. }) => {
-                eprintln!("[skip] generated IK did not converge after clamping");
-                continue;
-            }
-            Err(e) => return Err(e.into()),
-        };
+        let solved_joint_cmds =
+            match generated_compute_ik(target_link_idx, &target_pose, &init_joint_cmd_arr) {
+                Ok(cmds) => cmds,
+                Err(KinematicsError::IkDidNotConverge { .. }) => {
+                    eprintln!("[skip] generated IK did not converge after clamping");
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
         let solved_pose = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
 
         assert_galaw_transform_close(&target_pose, &solved_pose, &TEST_TOLERANCE);

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -81,10 +81,37 @@ fn assert_galaw_ik_correctness(
 
     let target_link_pose = galaw_model.compute_fk(target_joint_cmd)?[target_link_idx];
 
-    let solved_joint_cmds =
-        galaw_model.compute_ik(target_link_idx, &target_link_pose, init_joint_cmd)?;
-    let solved_link_poses = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
+    let solved_joint_cmds = match galaw_model.compute_ik(
+        target_link_idx, 
+        &target_link_pose, 
+        init_joint_cmd,
+    ) {
+        Ok(cmds) => cmds, 
+        Err(galaw::error::GalawError::Kinematics(KinematicsError::IkDidNotConverge { .. })) => {
+            eprintln!("[skip] IK did not converge after clamping");
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
 
+    // Joint commands must be within joint limits
+    for (joint, &cmd) in galaw_model
+        .joints
+        .iter()
+        .filter(|j| j.cmd_idx.is_some())
+        .zip(solved_joint_cmds.iter())
+    {
+        if let (Some(lo), Some(hi)) = (joint.limit_lower, joint.limit_upper) {
+            assert!(
+                (lo..=hi).contains(&cmd),
+                "joint '{}' command {cmd} outside limits [{lo}, {hi}]",
+                joint.name
+            );
+        }
+    }
+
+    let solved_link_poses =
+        galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
     assert_galaw_transform_close(&target_link_pose, &solved_link_poses, &TEST_TOLERANCE);
 
     Ok(())

--- a/tests/ik_correctness.rs
+++ b/tests/ik_correctness.rs
@@ -187,8 +187,14 @@ fn check_generated_matches_runtime<const N: usize>(
         let target_pose = galaw_model.compute_fk(&target_joint_cmd)?[target_link_idx];
 
         let init_joint_cmd_arr: [f64; N] = init_joint_cmd.try_into().unwrap();
-        let solved_joint_cmds =
-            generated_compute_ik(target_link_idx, &target_pose, &init_joint_cmd_arr)?;
+        let solved_joint_cmds = match generated_compute_ik(target_link_idx, &target_pose, &init_joint_cmd_arr) {
+            Ok(cmds) => cmds,
+            Err(KinematicsError::IkDidNotConverge { .. }) => {
+                eprintln!("[skip] generated IK did not converge after clamping");
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
         let solved_pose = galaw_model.compute_fk(&solved_joint_cmds)?[target_link_idx];
 
         assert_galaw_transform_close(&target_pose, &solved_pose, &TEST_TOLERANCE);


### PR DESCRIPTION
# Features
- Added joint clamping to make sure output of IK is valid joint ranges. 
- Modified the `ik_correctness` tests to check that the output of the IK achieves the target pose when checking with the forward kinematics function. Before, it was checking if the same joint angles were provided, but this was not a good test because of the null space (many valid solutions for one target pose). 

# Notes
- Because of the null space, IK is better handled by the end user. Might add more features to support this if there is demand, but for now, will offer a base version. 